### PR TITLE
Code cleanups

### DIFF
--- a/GPGME.Native.Shared/AlgorithmCapability.cs
+++ b/GPGME.Native.Shared/AlgorithmCapability.cs
@@ -11,9 +11,7 @@ namespace Libgpgme
             _type = type;
         }
 
-        public AlgorithmCapability Type {
-            get { return _type; }
-        }
+        public AlgorithmCapability Type => _type;
 
         public static string GetKeyUsageText(AlgorithmCapability type) {
             var caps = new List<string>();

--- a/gpgme-sharp/Context.cs
+++ b/gpgme-sharp/Context.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Globalization;
 using System.IO;
 using System.Runtime.InteropServices;
 using Libgpgme.Interop;

--- a/gpgme-sharp/DecryptionResult.cs
+++ b/gpgme-sharp/DecryptionResult.cs
@@ -6,10 +6,6 @@ namespace Libgpgme
 {
     public class DecryptionResult
     {
-        private string _file_name;
-        private Recipient _recipients;
-        private string _unsupported_algorithm;
-
         private bool _wrong_key_usage;
 
         internal DecryptionResult(IntPtr rstPtr) {
@@ -20,32 +16,24 @@ namespace Libgpgme
             UpdateFromMem(rstPtr);
         }
 
-        public string FileName {
-            get { return _file_name; }
-        }
+        public string FileName { get; private set; }
 
-        public bool WrongKeyUsage {
-            get { return _wrong_key_usage; }
-        }
+        public bool WrongKeyUsage => _wrong_key_usage;
 
-        public string UnsupportedAlgorithm {
-            get { return _unsupported_algorithm; }
-        }
+        public string UnsupportedAlgorithm { get; private set; }
 
-        public Recipient Recipients {
-            get { return _recipients; }
-        }
+        public Recipient Recipients { get; private set; }
 
         private void UpdateFromMem(IntPtr rstPtr) {
             var rst = new _gpgme_op_decrypt_result();
             Marshal.PtrToStructure(rstPtr, rst);
 
-            _file_name = Gpgme.PtrToStringUTF8(rst.file_name);
+            FileName = Gpgme.PtrToStringUTF8(rst.file_name);
             _wrong_key_usage = rst.wrong_key_usage;
-            _unsupported_algorithm = Gpgme.PtrToStringUTF8(rst.unsupported_algorithm);
+            UnsupportedAlgorithm = Gpgme.PtrToStringUTF8(rst.unsupported_algorithm);
 
             if (rst.recipients != IntPtr.Zero) {
-                _recipients = new Recipient(rst.recipients);
+                Recipients = new Recipient(rst.recipients);
             }
         }
     }

--- a/gpgme-sharp/EncryptionResult.cs
+++ b/gpgme-sharp/EncryptionResult.cs
@@ -6,10 +6,8 @@ namespace Libgpgme
 {
     public class EncryptionResult
     {
-        private InvalidKey _invalid_recipients;
-
         internal EncryptionResult(IntPtr rPtr) {
-            _invalid_recipients = null;
+            InvalidRecipients = null;
 
             if (rPtr == IntPtr.Zero) {
                 throw new InvalidPtrException("An invalid pointer for the encrypt_result structure has been supplied.");
@@ -17,16 +15,14 @@ namespace Libgpgme
             UpdateFromMem(rPtr);
         }
 
-        public InvalidKey InvalidRecipients {
-            get { return _invalid_recipients; }
-        }
+        public InvalidKey InvalidRecipients { get; private set; }
 
         private void UpdateFromMem(IntPtr rPtr) {
             var rst = new _gpgme_op_encrypt_result();
             Marshal.PtrToStructure(rPtr, rst);
 
             if (rst.invalid_recipients != IntPtr.Zero) {
-                _invalid_recipients = new InvalidKey(rst.invalid_recipients);
+                InvalidRecipients = new InvalidKey(rst.invalid_recipients);
             }
         }
     }

--- a/gpgme-sharp/EngineInfo.cs
+++ b/gpgme-sharp/EngineInfo.cs
@@ -99,16 +99,10 @@ namespace Libgpgme
             }
         }
 
-        public bool CtxValid {
-            // If the context invalides the engine object(s) invailde(s) as well.
-            get {
-                return HasCtx && _ctx.IsValid;
-            }
-        }
+        // If the context invalides the engine object(s) invailde(s) as well.
+        public bool CtxValid => HasCtx && _ctx.IsValid;
 
-        public bool HasCtx {
-            get { return (_ctx != null); }
-        }
+        public bool HasCtx => (_ctx != null);
 
         public EngineInfo Next {
             get {

--- a/gpgme-sharp/Exceptions/BadPassphraseException.cs
+++ b/gpgme-sharp/Exceptions/BadPassphraseException.cs
@@ -5,7 +5,7 @@ namespace Libgpgme
         public DecryptionResult DecryptionResult;
         public PassphraseInfo PassphraseInfo;
 
-        public BadPassphraseException() {
+        public BadPassphraseException(string message = null): base(message) {
         }
 
         public BadPassphraseException(DecryptionResult rst) {

--- a/gpgme-sharp/GenkeyResult.cs
+++ b/gpgme-sharp/GenkeyResult.cs
@@ -6,8 +6,6 @@ namespace Libgpgme
 {
     public class GenkeyResult
     {
-        private string _fingerprint;
-        private bool _has_primary;
         private bool _has_sub;
 
         internal GenkeyResult(IntPtr keyresultPtr) {
@@ -18,21 +16,17 @@ namespace Libgpgme
             UpdateFromMem(keyresultPtr);
         }
 
-        public string Fingerprint {
-            get { return _fingerprint; }
-        }
-        public bool HasPrimary {
-            get { return _has_primary; }
-        }
-        public bool HasSub {
-            get { return _has_sub; }
-        }
+        public string Fingerprint { get; private set; }
+
+        public bool HasPrimary { get; private set; }
+
+        public bool HasSub => _has_sub;
 
         private void UpdateFromMem(IntPtr keyresultPtr) {
             var result = new _gpgme_op_genkey_result();
             Marshal.PtrToStructure(keyresultPtr, result);
-            _fingerprint = Gpgme.PtrToStringAnsi(result.fpr);
-            _has_primary = result.primary;
+            Fingerprint = Gpgme.PtrToStringAnsi(result.fpr);
+            HasPrimary = result.primary;
             _has_sub = result.sub;
         }
     }

--- a/gpgme-sharp/Gpgme.cs
+++ b/gpgme-sharp/Gpgme.cs
@@ -12,9 +12,7 @@ namespace Libgpgme
 {
     public sealed class Gpgme
     {
-        public static GpgmeVersion Version {
-            get { return libgpgme.gpgme_version; }
-        }
+        public static GpgmeVersion Version => libgpgme.gpgme_version;
 
         public static string CheckVersion() {
             return libgpgme.gpgme_version_str;

--- a/gpgme-sharp/GpgmeData.cs
+++ b/gpgme-sharp/GpgmeData.cs
@@ -31,13 +31,13 @@ namespace Libgpgme
                 throw new InvalidDataBufferException("The data buffer is invalid.");
             }
             if (buffer == null) {
-                throw new ArgumentNullException("buffer", "An empty destination buffer has been given.");
+                throw new ArgumentNullException(nameof(buffer), "An empty destination buffer has been given.");
             }
             if (buffer.Length < (offset + count)) {
                 throw new ArgumentException("The sum of offset and count is bigger than the destination buffer size.");
             }
             if (offset < 0 || count < 0) {
-                throw new ArgumentOutOfRangeException("offset", "Invalid / negative offset or count value supplied.");
+                throw new ArgumentOutOfRangeException(nameof(offset), "Invalid / negative offset or count value supplied.");
             }
 
             GCHandle pinned_buffer = GCHandle.Alloc(buffer, GCHandleType.Pinned);
@@ -60,13 +60,13 @@ namespace Libgpgme
                 throw new InvalidDataBufferException("The data buffer is invalid.");
             }
             if (buffer == null) {
-                throw new ArgumentNullException("buffer", "An empty destination buffer has been given.");
+                throw new ArgumentNullException(nameof(buffer), "An empty destination buffer has been given.");
             }
             if (buffer.Length < count) {
                 throw new ArgumentException("Requested number of bytes to read is bigger than the destination buffer.");
             }
             if (count < 0) {
-                throw new ArgumentOutOfRangeException("count", "Negative read count value supplied.");
+                throw new ArgumentOutOfRangeException(nameof(count), "Negative read count value supplied.");
             }
 
             var bufsize = (UIntPtr) count;
@@ -116,7 +116,7 @@ namespace Libgpgme
                 throw new InvalidDataBufferException("Invalid data buffer");
             }
             if (buffer == null) {
-                throw new ArgumentNullException("buffer", "Empty source buffer given.");
+                throw new ArgumentNullException(nameof(buffer), "Empty source buffer given.");
             }
             if (buffer.Length < (offset + count)) {
                 throw new ArgumentException(
@@ -124,7 +124,7 @@ namespace Libgpgme
                         offset.ToString(CultureInfo.InvariantCulture) + ".");
             }
             if (offset < 0 || count < 0) {
-                throw new ArgumentOutOfRangeException("offset", "The offset or count is negative.");
+                throw new ArgumentOutOfRangeException(nameof(offset), "The offset or count is negative.");
             }
 
             GCHandle pinned_buffer = GCHandle.Alloc(buffer, GCHandleType.Pinned);
@@ -147,13 +147,13 @@ namespace Libgpgme
                 throw new InvalidDataBufferException("Invalid data buffer");
             }
             if (buffer == null) {
-                throw new ArgumentNullException("buffer", "An empty source buffer has been given.");
+                throw new ArgumentNullException(nameof(buffer), "An empty source buffer has been given.");
             }
             if (buffer.Length < count) {
                 throw new ArgumentException("Requested number of bytes to write is bigger than the source buffer.");
             }
             if (count < 0) {
-                throw new ArgumentOutOfRangeException("count", "The read count is negative.");
+                throw new ArgumentOutOfRangeException(nameof(count), "The read count is negative.");
             }
 
             var bufsize = (UIntPtr) count;
@@ -189,21 +189,14 @@ namespace Libgpgme
                     throw new InvalidDataBufferException();
                 }
                 if (value == null) {
-                    throw new ArgumentNullException("value", "Invalid file path.");
+                    throw new ArgumentNullException(nameof(value), "Invalid file path.");
                 }
 
                 IntPtr ptr = Marshal.StringToCoTaskMemAnsi(value);
                 if (!ptr.Equals(IntPtr.Zero)) {
-                    int err = libgpgme.NativeMethods.gpgme_data_set_file_name(dataPtr, ptr);
-                    gpg_err_code_t errcode = libgpgerror.gpg_err_code(err);
+                    GpgmeError.Check(libgpgme.NativeMethods.gpgme_data_set_file_name(dataPtr, ptr));
                     if (ptr != IntPtr.Zero) {
                         Marshal.FreeCoTaskMem(ptr);
-                    }
-                    if (errcode != gpg_err_code_t.GPG_ERR_NO_ERROR) {
-                        if (errcode == gpg_err_code_t.GPG_ERR_ENOMEM) {
-                            throw new OutOfMemoryException();
-                        }
-                        throw new GeneralErrorException("Unknown error " + errcode + " (" + err + ")");
                     }
                 } else {
                     throw new OutOfMemoryException();
@@ -227,11 +220,7 @@ namespace Libgpgme
 
                 var enc = (gpgme_data_encoding_t) value;
 
-                int err = libgpgme.NativeMethods.gpgme_data_set_encoding(dataPtr, enc);
-                gpg_err_code_t errcode = libgpgerror.gpg_err_code(err);
-                if (errcode != gpg_err_code_t.GPG_ERR_NO_ERROR) {
-                    throw new GeneralErrorException("Could not set data encoding to " + value);
-                }
+                GpgmeError.Check(libgpgme.NativeMethods.gpgme_data_set_encoding(dataPtr, enc));
             }
         }
 

--- a/gpgme-sharp/GpgmeError.cs
+++ b/gpgme-sharp/GpgmeError.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using Libgpgme.Interop;
+
+namespace Libgpgme
+{
+    public static class GpgmeError
+    {
+        /// <summary>
+        /// Throws an exception if <c>err</c> is not <c>GPG_ERR_NO_ERROR</c>.
+        /// </summary>
+        /// <param name="err">Error code</param>
+        public static void Check(int err)
+        {
+            var code = libgpgme.gpgme_err_code(err);
+            if (code != gpg_err_code_t.GPG_ERR_NO_ERROR)
+            {
+                throw CreateException(code);
+            }
+        }
+
+        /// <summary>
+        /// Converts a GPGME error code into an exception
+        /// </summary>
+        /// <param name="code">GPGME error code</param>
+        /// <returns>Exception</returns>
+        public static Exception CreateException(gpg_err_code_t code)
+        {
+            string message;
+            Gpgme.GetStrError((int)code, out message);
+            message = $"#{code}: ${message ?? "No error message available"}";
+
+            switch (code)
+            {
+                case gpg_err_code_t.GPG_ERR_AMBIGUOUS_NAME:
+                    return new AmbiguousKeyException(message);
+                case gpg_err_code_t.GPG_ERR_BAD_PASSPHRASE:
+                    return new BadPassphraseException(message);
+                case gpg_err_code_t.GPG_ERR_CONFLICT:
+                    return new KeyConflictException(message);
+                case gpg_err_code_t.GPG_ERR_DECRYPT_FAILED:
+                    return new DecryptionFailedException(message);
+                case gpg_err_code_t.GPG_ERR_INV_VALUE:
+                    return new InvalidPtrException(message);
+                case gpg_err_code_t.GPG_ERR_EBADF:
+                    return new InvalidDataBufferException(message);
+                case gpg_err_code_t.GPG_ERR_ENOMEM:
+                    return new OutOfMemoryException(message);
+                case gpg_err_code_t.GPG_ERR_NO_DATA:
+                    return new NoDataException(message);
+                case gpg_err_code_t.GPG_ERR_NO_PUBKEY:
+                    return new KeyNotFoundException(message);
+                case gpg_err_code_t.GPG_ERR_UNUSABLE_SECKEY:
+                    return new InvalidKeyException(message);
+                default:
+                    return new GeneralErrorException(message);
+            }
+        }
+    }
+}

--- a/gpgme-sharp/GpgmeStreamData.cs
+++ b/gpgme-sharp/GpgmeStreamData.cs
@@ -24,12 +24,9 @@ namespace Libgpgme
             }
         }
 
-        public override bool IsValid {
-            get {
-                return (iostream != null &&
-                    (!dataPtr.Equals(IntPtr.Zero)));
-            }
-        }
+        public override bool IsValid =>
+            (iostream != null &&
+             (!dataPtr.Equals(IntPtr.Zero)));
 
         public override long Length {
             get {
@@ -56,9 +53,8 @@ namespace Libgpgme
                 return false;
             }
         }
-        public override bool CanRelease {
-            get { return true; }
-        }
+        public override bool CanRelease => true;
+
         public override bool CanWrite {
             get {
                 if (iostream != null) {
@@ -76,8 +72,8 @@ namespace Libgpgme
             }
         }
         public Stream OriginStream {
-            get { return iostream; }
-            protected set { iostream = value; }
+            get => iostream;
+            protected set => iostream = value;
         }
 
         ~GpgmeStreamData() {

--- a/gpgme-sharp/GpgmeVersion.cs
+++ b/gpgme-sharp/GpgmeVersion.cs
@@ -7,13 +7,12 @@ namespace Libgpgme
         private readonly int _major;
         private readonly int _minor;
         private readonly int _update;
-        private readonly string _version;
 
         public GpgmeVersion(string version) {
             if (version == null) {
                 throw new ArgumentNullException("version");
             }
-            _version = version;
+            Version = version;
 
             string[] tup = version.Split('.');
             if (tup.Length >= 3) {
@@ -23,17 +22,12 @@ namespace Libgpgme
             }
         }
 
-        public int Major {
-            get { return _major; }
-        }
-        public int Minor {
-            get { return _minor; }
-        }
-        public int Update {
-            get { return _update; }
-        }
-        public string Version {
-            get { return _version; }
-        }
+        public int Major => _major;
+
+        public int Minor => _minor;
+
+        public int Update => _update;
+
+        public string Version { get; private set; }
     }
 }

--- a/gpgme-sharp/ImportResult.cs
+++ b/gpgme-sharp/ImportResult.cs
@@ -6,23 +6,9 @@ namespace Libgpgme
 {
     public class ImportResult
     {
-        /* Number of considered keys.  */
-        private int _considered;
-        private int _imported;
         private int _imported_rsa;
-        private ImportStatus _imports;
-        private int _new_revocations;
-        private int _new_signatures;
-        private int _new_sub_keys;
         private int _new_user_ids;
-
-        /* Keys without user ID.  */
-        private int _no_user_id;
-        private int _not_imported;
-        private int _secret_imported;
-        private int _secret_read;
         private int _secret_unchanged;
-        private int _skipped_new_keys;
         private int _unchanged;
 
         internal ImportResult(IntPtr resultPtr) {
@@ -33,99 +19,69 @@ namespace Libgpgme
             UpdateFromMem(resultPtr);
         }
 
-        public int Considered {
-            get { return _considered; }
-        }
+        public int Considered { get; private set; }
 
-        public int NoUserId {
-            get { return _no_user_id; }
-        }
+        public int NoUserId { get; private set; }
 
         /* Imported keys.  */
-        public int Imported {
-            get { return _imported; }
-        }
+        public int Imported { get; private set; }
 
         /* Imported RSA keys.  */
-        public int ImportedRSA {
-            get { return _imported_rsa; }
-        }
+        public int ImportedRSA => _imported_rsa;
 
         /* Unchanged keys.  */
-        public int Unchanged {
-            get { return _unchanged; }
-        }
+        public int Unchanged => _unchanged;
 
         /* Number of new user ids.  */
-        public int NewUserIds {
-            get { return _new_user_ids; }
-        }
+        public int NewUserIds => _new_user_ids;
 
         /* Number of new sub keys.  */
-        public int NewSubkeys {
-            get { return _new_sub_keys; }
-        }
+        public int NewSubkeys { get; private set; }
 
         /* Number of new signatures.  */
-        public int NewSignatures {
-            get { return _new_signatures; }
-        }
+        public int NewSignatures { get; private set; }
 
         /* Number of new revocations.  */
-        public int NewRevocations {
-            get { return _new_revocations; }
-        }
+        public int NewRevocations { get; private set; }
 
         /* Number of secret keys read.  */
-        public int SecretRead {
-            get { return _secret_read; }
-        }
+        public int SecretRead { get; private set; }
 
         /* Number of secret keys imported.  */
-        public int SecretImported {
-            get { return _secret_imported; }
-        }
+        public int SecretImported { get; private set; }
 
         /* Number of secret keys unchanged.  */
-        public int SecretUnchanged {
-            get { return _secret_unchanged; }
-        }
+        public int SecretUnchanged => _secret_unchanged;
 
         /* Number of new keys skipped.  */
-        public int SkippedNewKeys {
-            get { return _skipped_new_keys; }
-        }
+        public int SkippedNewKeys { get; private set; }
 
         /* Number of keys not imported.  */
-        public int NotImported {
-            get { return _not_imported; }
-        }
+        public int NotImported { get; private set; }
 
-        public ImportStatus Imports {
-            get { return _imports; }
-        }
+        public ImportStatus Imports { get; private set; }
 
         private void UpdateFromMem(IntPtr resultPtr) {
             var result = new _gpgme_op_import_result();
             Marshal.PtrToStructure(resultPtr, result);
 
-            _considered = result.considered;
-            _no_user_id = result.no_user_id;
-            _imported = result.imported;
+            Considered = result.considered;
+            NoUserId = result.no_user_id;
+            Imported = result.imported;
             _imported_rsa = result.imported_rsa;
             _unchanged = result.unchanged;
             _new_user_ids = result.new_user_ids;
-            _new_sub_keys = result.new_sub_keys;
-            _new_signatures = result.new_signatures;
-            _new_revocations = result.new_revocations;
-            _secret_read = result.secret_read;
-            _secret_imported = result.secret_imported;
+            NewSubkeys = result.new_sub_keys;
+            NewSignatures = result.new_signatures;
+            NewRevocations = result.new_revocations;
+            SecretRead = result.secret_read;
+            SecretImported = result.secret_imported;
             _secret_unchanged = result.secret_unchanged;
-            _skipped_new_keys = result.skipped_new_keys;
-            _not_imported = result.not_imported;
+            SkippedNewKeys = result.skipped_new_keys;
+            NotImported = result.not_imported;
 
             if (result.imports != IntPtr.Zero) {
-                _imports = new ImportStatus(result.imports);
+                Imports = new ImportStatus(result.imports);
             }
         }
     }

--- a/gpgme-sharp/ImportStatus.cs
+++ b/gpgme-sharp/ImportStatus.cs
@@ -8,9 +8,6 @@ namespace Libgpgme
 {
     public class ImportStatus : IEnumerable<ImportStatus>
     {
-        private string _fpr; // char *
-        private ImportStatus _next;
-        private int _result; //gpgme_error_t
         private uint _status;
 
         internal ImportStatus(IntPtr statusPtr) {
@@ -21,49 +18,34 @@ namespace Libgpgme
             UpdateFromMem(statusPtr);
         }
 
-        public ImportStatus Next {
-            get { return _next; }
-        }
+        public ImportStatus Next { get; private set; }
 
         /* Fingerprint.  */
-        public String Fpr {
-            get { return _fpr; }
-        }
+        public String Fpr { get; private set; }
 
         /* If a problem occured, the reason why the key could not be
            imported.  Otherwise GPGME_No_Error.  */
-        public int Result {
-            get { return _result; }
-        }
+        public int Result { get; private set; }
 
         /* The result of the import, the GPGME_IMPORT_* values bit-wise
            ORed.  0 means the key was already known and no new components
            have been added.  */
 
         /* The key was new.  */
-        public bool NewKey {
-            get { return ((_status & (uint) ImportStatusFlags.New) > 0); }
-        }
+        public bool NewKey => ((_status & (uint) ImportStatusFlags.New) > 0);
 
         /* The key contained new user IDs.  */
-        public bool HasNewUids {
-            get { return ((_status & (uint) ImportStatusFlags.Uid) > 0); }
-        }
+        public bool HasNewUids => ((_status & (uint) ImportStatusFlags.Uid) > 0);
 
         /* The key contained new signatures.  */
-        public bool HasNewSignatures {
-            get { return ((_status & (uint) ImportStatusFlags.Signature) > 0); }
-        }
+        public bool HasNewSignatures => ((_status & (uint) ImportStatusFlags.Signature) > 0);
 
         /* The key contained new sub keys.  */
-        public bool HasNewSubkeys {
-            get { return ((_status & (uint) ImportStatusFlags.Subkey) > 0); }
-        }
+        public bool HasNewSubkeys => ((_status & (uint) ImportStatusFlags.Subkey) > 0);
 
         /* The key contained a secret key.  */
-        public bool NewSecretKey {
-            get { return ((_status & (uint) ImportStatusFlags.Secret) > 0); }
-        }
+        public bool NewSecretKey => ((_status & (uint) ImportStatusFlags.Secret) > 0);
+
         #region IEnumerable<ImportStatus> Members
 
         public IEnumerator<ImportStatus> GetEnumerator() {
@@ -84,12 +66,12 @@ namespace Libgpgme
             Marshal.PtrToStructure(statusPtr, result);
 
             if (result.fpr != IntPtr.Zero) {
-                _fpr = Gpgme.PtrToStringAnsi(result.fpr);
+                Fpr = Gpgme.PtrToStringAnsi(result.fpr);
             }
             _status = result.status;
-            _result = result.result;
+            Result = result.result;
             if (result.next != IntPtr.Zero) {
-                _next = new ImportStatus(result.next);
+                Next = new ImportStatus(result.next);
             }
         }
     }

--- a/gpgme-sharp/Interop/_gpgme_key.cs
+++ b/gpgme-sharp/Interop/_gpgme_key.cs
@@ -86,7 +86,7 @@ namespace Libgpgme.Interop
         }
 
         public bool revoked {
-            get { return ((flags & 1) > 0); }
+            get => ((flags & 1) > 0);
             set {
                 if (value) {
                     flags |= 1;
@@ -96,7 +96,7 @@ namespace Libgpgme.Interop
             }
         }
         public bool expired {
-            get { return ((flags & 2) > 0); }
+            get => ((flags & 2) > 0);
             set {
                 if (value) {
                     flags |= 2;
@@ -106,7 +106,7 @@ namespace Libgpgme.Interop
             }
         }
         public bool disabled {
-            get { return ((flags & 4) > 0); }
+            get => ((flags & 4) > 0);
             set {
                 if (value) {
                     flags |= 4;
@@ -116,7 +116,7 @@ namespace Libgpgme.Interop
             }
         }
         public bool invalid {
-            get { return ((flags & 8) > 0); }
+            get => ((flags & 8) > 0);
             set {
                 if (value) {
                     flags |= 8;
@@ -126,7 +126,7 @@ namespace Libgpgme.Interop
             }
         }
         public bool can_encrypt {
-            get { return ((flags & 16) > 0); }
+            get => ((flags & 16) > 0);
             set {
                 if (value) {
                     flags |= 16;
@@ -136,7 +136,7 @@ namespace Libgpgme.Interop
             }
         }
         public bool can_sign {
-            get { return ((flags & 32) > 0); }
+            get => ((flags & 32) > 0);
             set {
                 if (value) {
                     flags |= 32;
@@ -146,7 +146,7 @@ namespace Libgpgme.Interop
             }
         }
         public bool can_certify {
-            get { return ((flags & 64) > 0); }
+            get => ((flags & 64) > 0);
             set {
                 if (value) {
                     flags |= 64;
@@ -156,7 +156,7 @@ namespace Libgpgme.Interop
             }
         }
         public bool secret {
-            get { return ((flags & 128) > 0); }
+            get => ((flags & 128) > 0);
             set {
                 if (value) {
                     flags |= 128;
@@ -166,7 +166,7 @@ namespace Libgpgme.Interop
             }
         }
         public bool can_authenticate {
-            get { return ((flags & 256) > 0); }
+            get => ((flags & 256) > 0);
             set {
                 if (value) {
                     flags |= 256;
@@ -176,7 +176,7 @@ namespace Libgpgme.Interop
             }
         }
         public bool is_qualified {
-            get { return ((flags & 512) > 0); }
+            get => ((flags & 512) > 0);
             set {
                 if (value) {
                     flags |= 512;

--- a/gpgme-sharp/Interop/_gpgme_key_sig.cs
+++ b/gpgme-sharp/Interop/_gpgme_key_sig.cs
@@ -79,7 +79,7 @@ namespace Libgpgme.Interop
         }
 
         public bool revoked {
-            get { return ((flags & 1) > 0); }
+            get => ((flags & 1) > 0);
             set {
                 if (value) {
                     flags |= 1;
@@ -90,7 +90,7 @@ namespace Libgpgme.Interop
         }
 
         public bool expired {
-            get { return ((flags & 2) > 0); }
+            get => ((flags & 2) > 0);
             set {
                 if (value) {
                     flags |= 2;
@@ -102,7 +102,7 @@ namespace Libgpgme.Interop
 
 
         public bool invalid {
-            get { return ((flags & 4) > 0); }
+            get => ((flags & 4) > 0);
             set {
                 if (value) {
                     flags |= 4;
@@ -113,7 +113,7 @@ namespace Libgpgme.Interop
         }
 
         public bool exportable {
-            get { return ((flags & 8) > 0); }
+            get => ((flags & 8) > 0);
             set {
                 if (value) {
                     flags |= 8;

--- a/gpgme-sharp/Interop/_gpgme_op_decrypt_result.cs
+++ b/gpgme-sharp/Interop/_gpgme_op_decrypt_result.cs
@@ -23,7 +23,7 @@ namespace Libgpgme.Interop
         public IntPtr file_name; //char *
 
         public bool wrong_key_usage {
-            get { return ((flags & 1) > 0); }
+            get => ((flags & 1) > 0);
             set {
                 if (value) {
                     flags |= 1;

--- a/gpgme-sharp/Interop/_gpgme_op_genkey_result.cs
+++ b/gpgme-sharp/Interop/_gpgme_op_genkey_result.cs
@@ -11,7 +11,7 @@ namespace Libgpgme.Interop
 
         /* A primary key was generated.  */
         public bool primary {
-            get { return ((flags & 1) > 0); }
+            get => ((flags & 1) > 0);
             set {
                 if (value) {
                     flags |= 1;
@@ -22,7 +22,7 @@ namespace Libgpgme.Interop
         }
         /* A sub key was generated.  */
         public bool sub {
-            get { return ((flags & 2) > 0); }
+            get => ((flags & 2) > 0);
             set {
                 if (value) {
                     flags |= 2;

--- a/gpgme-sharp/Interop/_gpgme_op_keylist_result.cs
+++ b/gpgme-sharp/Interop/_gpgme_op_keylist_result.cs
@@ -8,7 +8,7 @@ namespace Libgpgme.Interop
         public uint flags;
 
         public bool truncated {
-            get { return ((flags & 1) > 0); }
+            get => ((flags & 1) > 0);
             set {
                 if (value) {
                     flags |= 1;

--- a/gpgme-sharp/Interop/_gpgme_sig_notation.cs
+++ b/gpgme-sharp/Interop/_gpgme_sig_notation.cs
@@ -34,7 +34,7 @@ namespace Libgpgme.Interop
         public uint additionalflags;
 
         public bool human_readable {
-            get { return ((additionalflags & 1) > 0); }
+            get => ((additionalflags & 1) > 0);
             set {
                 if (value) {
                     additionalflags |= 1;
@@ -44,7 +44,7 @@ namespace Libgpgme.Interop
             }
         }
         public bool critical {
-            get { return ((additionalflags & 2) > 0); }
+            get => ((additionalflags & 2) > 0);
             set {
                 if (value) {
                     additionalflags |= 2;

--- a/gpgme-sharp/Interop/_gpgme_signature.cs
+++ b/gpgme-sharp/Interop/_gpgme_signature.cs
@@ -56,7 +56,7 @@ namespace Libgpgme.Interop
         public IntPtr pka_address; // char *
 
         public bool wrong_key_usage {
-            get { return ((flags & 1) > 0); }
+            get => ((flags & 1) > 0);
             set {
                 if (value) {
                     flags |= 1;
@@ -66,11 +66,11 @@ namespace Libgpgme.Interop
             }
         }
         public PkaStatus pka_trust {
-            get { return (PkaStatus) ((flags & 6) >> 1); }
-            set { flags = (flags & 0xFFFFFFF9) | (((uint) value) << 1); }
+            get => (PkaStatus) ((flags & 6) >> 1);
+            set => flags = (flags & 0xFFFFFFF9) | (((uint) value) << 1);
         }
         public bool chain_model {
-            get { return ((flags & 8) > 0); }
+            get => ((flags & 8) > 0);
             set {
                 if (value) {
                     flags |= 8;

--- a/gpgme-sharp/Interop/_gpgme_signature_windows.cs
+++ b/gpgme-sharp/Interop/_gpgme_signature_windows.cs
@@ -61,7 +61,7 @@ namespace Libgpgme.Interop
         public IntPtr pka_address; // char *
 
         public bool wrong_key_usage {
-            get { return ((flags & 1) > 0); }
+            get => ((flags & 1) > 0);
             set {
                 if (value) {
                     flags |= 1;
@@ -71,11 +71,11 @@ namespace Libgpgme.Interop
             }
         }
         public PkaStatus pka_trust {
-            get { return (PkaStatus) ((flags & 6) >> 1); }
-            set { flags = (flags & 0xFFFFFFF9) | (((uint) value) << 1); }
+            get => (PkaStatus) ((flags & 6) >> 1);
+            set => flags = (flags & 0xFFFFFFF9) | (((uint) value) << 1);
         }
         public bool chain_model {
-            get { return ((flags & 8) > 0); }
+            get => ((flags & 8) > 0);
             set {
                 if (value) {
                     flags |= 8;

--- a/gpgme-sharp/Interop/_gpgme_subkey.cs
+++ b/gpgme-sharp/Interop/_gpgme_subkey.cs
@@ -67,7 +67,7 @@ namespace Libgpgme.Interop
         public IntPtr expires;
 
         public bool revoked {
-            get { return ((flags & 1) > 0); }
+            get => ((flags & 1) > 0);
             set {
                 if (value) {
                     flags |= 1;
@@ -77,7 +77,7 @@ namespace Libgpgme.Interop
             }
         }
         public bool expired {
-            get { return ((flags & 2) > 0); }
+            get => ((flags & 2) > 0);
             set {
                 if (value) {
                     flags |= 2;
@@ -87,7 +87,7 @@ namespace Libgpgme.Interop
             }
         }
         public bool disabled {
-            get { return ((flags & 4) > 0); }
+            get => ((flags & 4) > 0);
             set {
                 if (value) {
                     flags |= 4;
@@ -97,7 +97,7 @@ namespace Libgpgme.Interop
             }
         }
         public bool invalid {
-            get { return ((flags & 8) > 0); }
+            get => ((flags & 8) > 0);
             set {
                 if (value) {
                     flags |= 8;
@@ -107,7 +107,7 @@ namespace Libgpgme.Interop
             }
         }
         public bool can_encrypt {
-            get { return ((flags & 16) > 0); }
+            get => ((flags & 16) > 0);
             set {
                 if (value) {
                     flags |= 16;
@@ -117,7 +117,7 @@ namespace Libgpgme.Interop
             }
         }
         public bool can_sign {
-            get { return ((flags & 32) > 0); }
+            get => ((flags & 32) > 0);
             set {
                 if (value) {
                     flags |= 32;
@@ -127,7 +127,7 @@ namespace Libgpgme.Interop
             }
         }
         public bool can_certify {
-            get { return ((flags & 64) > 0); }
+            get => ((flags & 64) > 0);
             set {
                 if (value) {
                     flags |= 64;
@@ -137,7 +137,7 @@ namespace Libgpgme.Interop
             }
         }
         public bool secret {
-            get { return ((flags & 128) > 0); }
+            get => ((flags & 128) > 0);
             set {
                 if (value) {
                     flags |= 128;
@@ -147,7 +147,7 @@ namespace Libgpgme.Interop
             }
         }
         public bool can_authenticate {
-            get { return ((flags & 256) > 0); }
+            get => ((flags & 256) > 0);
             set {
                 if (value) {
                     flags |= 256;
@@ -157,7 +157,7 @@ namespace Libgpgme.Interop
             }
         }
         public bool is_qualified {
-            get { return ((flags & 512) > 0); }
+            get => ((flags & 512) > 0);
             set {
                 if (value) {
                     flags |= 512;

--- a/gpgme-sharp/Interop/_gpgme_user_id.cs
+++ b/gpgme-sharp/Interop/_gpgme_user_id.cs
@@ -41,7 +41,7 @@ namespace Libgpgme.Interop
         public IntPtr _last_keysig; //gpgme_key_sig_t
 
         public bool revoked {
-            get { return ((flags & 1) > 0); }
+            get => ((flags & 1) > 0);
             set {
                 if (value) {
                     flags |= 1;
@@ -51,7 +51,7 @@ namespace Libgpgme.Interop
             }
         }
         public bool invalid {
-            get { return ((flags & 2) > 0); }
+            get => ((flags & 2) > 0);
             set {
                 if (value) {
                     flags |= 2;

--- a/gpgme-sharp/InvalidKey.cs
+++ b/gpgme-sharp/InvalidKey.cs
@@ -8,8 +8,6 @@ namespace Libgpgme
 {
     public class InvalidKey : IEnumerable<InvalidKey>
     {
-        private string _fpr;
-        private InvalidKey _next;
         private int _reason;
 
         internal InvalidKey(IntPtr sPtr) {
@@ -19,16 +17,12 @@ namespace Libgpgme
             UpdateFromMem(sPtr);
         }
 
-        public string Fingerprint {
-            get { return _fpr; }
-        }
+        public string Fingerprint { get; private set; }
 
-        public int Reason {
-            get { return _reason; }
-        }
-        public InvalidKey Next {
-            get { return _next; }
-        }
+        public int Reason => _reason;
+
+        public InvalidKey Next { get; private set; }
+
         #region IEnumerable<InvalidKey> Members
 
         IEnumerator IEnumerable.GetEnumerator() {
@@ -48,11 +42,11 @@ namespace Libgpgme
             var ikey = new _gpgme_invalid_key();
             Marshal.PtrToStructure(sPtr, ikey);
 
-            _fpr = Gpgme.PtrToStringAnsi(ikey.fpr);
+            Fingerprint = Gpgme.PtrToStringAnsi(ikey.fpr);
             _reason = ikey.reason;
 
             if (ikey.next != IntPtr.Zero) {
-                _next = new InvalidKey(ikey.next);
+                Next = new InvalidKey(ikey.next);
             }
         }
     }

--- a/gpgme-sharp/Key.cs
+++ b/gpgme-sharp/Key.cs
@@ -40,7 +40,7 @@ namespace Libgpgme
 
         public UserId Uids { get; private set; }
         // The first one in the list is the main/primary UserID
-        public UserId Uid { get { return Uids; } }
+        public UserId Uid => Uids;
 
         public Subkey Subkeys { get; private set; }
         // The first subkey in the linked list is the primary key
@@ -53,16 +53,12 @@ namespace Libgpgme
             }
         }
         // The first subkey in the linked list is the primary key
-        public string Fingerprint {
-            get {
-                return Subkeys != null 
-                    ? Subkeys.Fingerprint 
-                    : null;
-            }
-        }
-        internal virtual IntPtr KeyPtr {
-            get { return _key_ptr; }
-        }
+        public string Fingerprint =>
+            Subkeys != null 
+                ? Subkeys.Fingerprint 
+                : null;
+
+        internal virtual IntPtr KeyPtr => _key_ptr;
 
         #region IDisposable Members
 

--- a/gpgme-sharp/KeyParameters.cs
+++ b/gpgme-sharp/KeyParameters.cs
@@ -12,78 +12,51 @@ namespace Libgpgme
         public const int KEY_LENGTH_4096 = 4096;
 
         private static readonly DateTime _unixdate = new DateTime(1970, 1, 1);
-        private bool _autoalgocap = true;
-
         private string _comment = "";
         private string _email = "";
-        private DateTime _expirationdate = _unixdate;
         private const string FORMAT = "internal";
-        private int _keylength = KEY_LENGTH_1024;
-        // X.509
-        private string _namedn;
-        private bool _nosubkey;
+
         private string _passphrase = "";
-        private AlgorithmCapability _pubkeycap = AlgorithmCapability.CanSign | AlgorithmCapability.CanCert | AlgorithmCapability.CanAuth;
         private KeyAlgorithm _pubkeytype = KeyAlgorithm.DSA;
         private string _realname = "";
-        private AlgorithmCapability _subkeycap = AlgorithmCapability.CanEncrypt;
-        private int _subkeylength = KEY_LENGTH_1024;
         private KeyAlgorithm _subkeytype = KeyAlgorithm.ELG_E;
 
         /* If set to TRUE: everytime the user changes the *keytype 
          * (algorithm) of the pub or sub key the class
          * automatically finds the correct key usage flags.
          */
-        public bool AutoKeyUsage {
-            get { return _autoalgocap; }
-            set { _autoalgocap = value; }
-        }
+        public bool AutoKeyUsage { get; set; } = true;
 
         public KeyAlgorithm PubkeyAlgorithm {
-            get { return _pubkeytype; }
+            get => _pubkeytype;
             set {
                 _pubkeytype = value;
-                if (_autoalgocap) {
-                    _pubkeycap = Gpgme.GetAlgorithmCapability(value);
+                if (AutoKeyUsage) {
+                    PubkeyUsage = Gpgme.GetAlgorithmCapability(value);
                 }
             }
         }
-        public AlgorithmCapability PubkeyUsage {
-            get { return _pubkeycap; }
-            set { _pubkeycap = value; }
-        }
-        public int KeyLength {
-            get { return _keylength; }
-            set { _keylength = value; }
-        }
+        public AlgorithmCapability PubkeyUsage { get; set; } = AlgorithmCapability.CanSign | AlgorithmCapability.CanCert | AlgorithmCapability.CanAuth;
+        public int KeyLength { get; set; } = KEY_LENGTH_1024;
         public int PubkeyLength {
-            get { return KeyLength; }
-            set { KeyLength = value; }
+            get => KeyLength;
+            set => KeyLength = value;
         }
-        public bool NoSubkey {
-            get { return _nosubkey; }
-            set { _nosubkey = value; }
-        }
+        public bool NoSubkey { get; set; }
         public KeyAlgorithm SubkeyAlgorithm {
-            get { return _subkeytype; }
+            get => _subkeytype;
             set {
                 _subkeytype = value;
-                if (_autoalgocap) {
-                    _subkeycap = Gpgme.GetAlgorithmCapability(value);
+                if (AutoKeyUsage) {
+                    SubkeyUsage = Gpgme.GetAlgorithmCapability(value);
                 }
             }
         }
-        public AlgorithmCapability SubkeyUsage {
-            get { return _subkeycap; }
-            set { _subkeycap = value; }
-        }
+        public AlgorithmCapability SubkeyUsage { get; set; } = AlgorithmCapability.CanEncrypt;
 
-        public int SubkeyLength {
-            get { return _subkeylength; }
-            set { _subkeylength = value; }
-        }
+        public int SubkeyLength { get; set; } = KEY_LENGTH_1024;
         public string RealName {
-            get { return _realname; }
+            get => _realname;
             set {
                 if (CheckForInvalidChars(value)) {
                     throw new InvalidPassphraseException("Real name contains invalid chars.");
@@ -92,7 +65,7 @@ namespace Libgpgme
             }
         }
         public string Comment {
-            get { return _comment; }
+            get => _comment;
             set {
                 if (CheckForInvalidChars(value)) {
                     throw new InvalidPassphraseException("Comment contains invalid chars.");
@@ -101,7 +74,7 @@ namespace Libgpgme
             }
         }
         public string Email {
-            get { return _email; }
+            get => _email;
             set {
                 if (CheckForInvalidChars(value)) {
                     throw new InvalidPassphraseException("Email contains invalid chars.");
@@ -109,12 +82,9 @@ namespace Libgpgme
                 _email = value;
             }
         }
-        public DateTime ExpirationDate {
-            get { return _expirationdate; }
-            set { _expirationdate = value; }
-        }
+        public DateTime ExpirationDate { get; set; } = _unixdate;
         public string Passphrase {
-            get { return _passphrase; }
+            get => _passphrase;
             set {
                 if (CheckForInvalidChars(value)) {
                     throw new InvalidPassphraseException("Passphrase contains invalid chars.");
@@ -122,13 +92,8 @@ namespace Libgpgme
                 _passphrase = value;
             }
         }
-        public string NameDN {
-            get { return _namedn; }
-            set { _namedn = value; }
-        }
-        public bool IsInfinitely {
-            get { return _expirationdate.Equals(_unixdate); }
-        }
+        public string NameDN { get; set; }
+        public bool IsInfinitely => ExpirationDate.Equals(_unixdate);
 
         internal string GetXmlText(Protocol protocoltype) {
             var sb = new StringBuilder();
@@ -150,19 +115,19 @@ namespace Libgpgme
                     }
 
                     // invalid capability attribute
-                    if ((_pubkeycap & AlgorithmCapability.CanSign) != AlgorithmCapability.CanSign) {
+                    if ((PubkeyUsage & AlgorithmCapability.CanSign) != AlgorithmCapability.CanSign) {
                         throw new InvalidPubkeyAlgoException("The primary key must have sign capabilies.");
                     }
 
                     sb.Append("<GnupgKeyParms format=\"" + FORMAT + "\">\n");
                     sb.Append("Key-Type: " + GetAttrDesc(_pubkeytype) + "\n");
                     sb.Append("Key-Usage: ");
-                    sb.Append(AlgorithmCapabilityAttribute.GetKeyUsageText(_pubkeycap));
+                    sb.Append(AlgorithmCapabilityAttribute.GetKeyUsageText(PubkeyUsage));
                     sb.Append("\n");
 
-                    sb.Append("Key-Length: " + _keylength + "\n");
+                    sb.Append("Key-Length: " + KeyLength + "\n");
 
-                    if (!_nosubkey) {
+                    if (!NoSubkey) {
                         if (_subkeytype == KeyAlgorithm.RSA_E || // RSA-S/E are obsolete [RFC4880#9.1]
                             _subkeytype == KeyAlgorithm.RSA_S) {
                             throw new InvalidPubkeyAlgoException(
@@ -172,10 +137,10 @@ namespace Libgpgme
                         sb.Append("Subkey-Type: " + GetAttrDesc(_subkeytype) + "\n");
 
                         sb.Append("Subkey-Usage: ");
-                        sb.Append(AlgorithmCapabilityAttribute.GetKeyUsageText(_subkeycap));
+                        sb.Append(AlgorithmCapabilityAttribute.GetKeyUsageText(SubkeyUsage));
                         sb.Append("\n");
 
-                        sb.Append("Subkey-Length: " + _subkeylength + "\n");
+                        sb.Append("Subkey-Length: " + SubkeyLength + "\n");
                     }
 
                     sb.Append("Name-Real: " + _realname + "\n");
@@ -183,11 +148,11 @@ namespace Libgpgme
                         sb.Append("Name-Comment: " + _comment + "\n");
                     }
                     sb.Append("Name-Email: " + _email + "\n");
-                    if (_expirationdate.Equals(_unixdate)) {
+                    if (ExpirationDate.Equals(_unixdate)) {
                         // 0 means the key lifetime is infinitely
                         sb.Append("Expire-Date: 0\n");
                     } else {
-                        sb.Append("Expire-Date: " + _expirationdate.ToString("yyyy-MM-dd") + "\n");
+                        sb.Append("Expire-Date: " + ExpirationDate.ToString("yyyy-MM-dd") + "\n");
                     }
                     if (!string.IsNullOrEmpty(_passphrase)) {
                         sb.Append("Passphrase: " + _passphrase + "\n");
@@ -198,8 +163,8 @@ namespace Libgpgme
                 case Protocol.CMS:
                     sb.Append("<GnupgKeyParms format=\"" + FORMAT + "\">\n");
                     sb.Append("Key-Type: " + GetAttrDesc(_pubkeytype) + "\n");
-                    sb.Append("Key-Length: " + _keylength + "\n");
-                    sb.Append("Name-DN: " + _namedn + "\n");
+                    sb.Append("Key-Length: " + KeyLength + "\n");
+                    sb.Append("Name-DN: " + NameDN + "\n");
                     sb.Append("Name-Email: " + _email + "\n");
                     sb.Append("</GnupgKeyParms>");
                     break;
@@ -222,7 +187,7 @@ namespace Libgpgme
         }
 
         public void MakeInfinitely() {
-            _expirationdate = _unixdate;
+            ExpirationDate = _unixdate;
         }
 
         private bool CheckForInvalidChars(string str) {

--- a/gpgme-sharp/KeySignature.cs
+++ b/gpgme-sharp/KeySignature.cs
@@ -34,23 +34,16 @@ namespace Libgpgme
         public SignatureNotation Notations { get; private set; }
         public KeySignature Next { get; private set; }
 
-        public DateTime Timestamp {
-            get { return Gpgme.ConvertFromUnix(_timestamp); }
-        }
-        public DateTime TimestampUTC {
-            get { return Gpgme.ConvertFromUnixUTC(_timestamp); }
-        }
+        public DateTime Timestamp => Gpgme.ConvertFromUnix(_timestamp);
 
-        public DateTime Expires {
-            get { return Gpgme.ConvertFromUnix(_expires); }
-        }
-        public DateTime ExpiresUTC {
-            get { return Gpgme.ConvertFromUnixUTC(_expires); }
-        }
+        public DateTime TimestampUTC => Gpgme.ConvertFromUnixUTC(_timestamp);
 
-        public bool IsInfinitely {
-            get { return _expires == 0; }
-        }
+        public DateTime Expires => Gpgme.ConvertFromUnix(_expires);
+
+        public DateTime ExpiresUTC => Gpgme.ConvertFromUnixUTC(_expires);
+
+        public bool IsInfinitely => _expires == 0;
+
         #region IEnumerable<KeySignature> Members
 
         public IEnumerator<KeySignature> GetEnumerator() {

--- a/gpgme-sharp/KeyStore.cs
+++ b/gpgme-sharp/KeyStore.cs
@@ -105,13 +105,7 @@ namespace Libgpgme
             }
 
             lock (_ctx.CtxLock) {
-                int err = libgpgme.NativeMethods.gpgme_op_import(_ctx.CtxPtr, keydata.dataPtr);
-                gpg_err_code_t errcode = libgpgerror.gpg_err_code(err);
-
-                if (errcode != gpg_err_code_t.GPG_ERR_NO_ERROR) {
-                    throw new KeyImportException("Error " + errcode, err);
-                }
-
+                GpgmeError.Check(libgpgme.NativeMethods.gpgme_op_import(_ctx.CtxPtr, keydata.dataPtr));
                 IntPtr result = libgpgme.NativeMethods.gpgme_op_import_result(_ctx.CtxPtr);
                 return new ImportResult(result);
             }
@@ -165,11 +159,7 @@ namespace Libgpgme
             // Free memory 
             Gpgme.FreeStringArray(parray);
 
-            gpg_err_code_t errcode = libgpgerror.gpg_err_code(err);
-
-            if (errcode != gpg_err_code_t.GPG_ERR_NO_ERROR) {
-                throw new KeyExportException("Error " + errcode, err);
-            }
+            GpgmeError.Check(err);
         }
 
         public Key GetKey(string fpr, bool secretOnly) {
@@ -371,7 +361,7 @@ namespace Libgpgme
                     if (pattern_ptr != IntPtr.Zero) {
                         Marshal.FreeCoTaskMem(pattern_ptr);
                     }
-                    throw new GeneralErrorException("An unexpected error occurred. Error: " + err.ToString(CultureInfo.InvariantCulture));
+                    throw GpgmeError.CreateException(errcode);
                 }
 
                 while (errcode == gpg_err_code_t.GPG_ERR_NO_ERROR) {
@@ -391,7 +381,7 @@ namespace Libgpgme
                 }
 
                 if (errcode != gpg_err_code_t.GPG_ERR_EOF) {
-                    throw new GeneralErrorException("An unexpected error occurred. " + errcode.ToString());
+                    throw GpgmeError.CreateException(errcode);
                 }
             }
 

--- a/gpgme-sharp/PassphraseInfo.cs
+++ b/gpgme-sharp/PassphraseInfo.cs
@@ -26,15 +26,11 @@ namespace Libgpgme
             ParseInfo();
         }
 
-        public IntPtr Hook {
-            get { return hook; }
-        }
-        public string HintText {
-            get { return hintText; }
-        }
-        public string Info {
-            get { return info; }
-        }
+        public IntPtr Hook => hook;
+
+        public string HintText => hintText;
+
+        public string Info => info;
 
         private void ParseHintText() {
             if (hintText != null) {

--- a/gpgme-sharp/PgpExpirationOptions.cs
+++ b/gpgme-sharp/PgpExpirationOptions.cs
@@ -5,25 +5,18 @@ namespace Libgpgme
     public class PgpExpirationOptions
     {
         private static readonly DateTime _unix_date = new DateTime(1970, 1, 1);
-        private DateTime _expiration_date = _unix_date;
-
         public int[] SelectedSubkeys; // if not set - expire the whole key (pub SC)
         
         internal bool cmdSend;
         internal bool forceQuit;
         internal int nsubkey;
 
-        public bool IsInfinitely {
-            get { return _expiration_date.Equals(_unix_date); }
-        }
+        public bool IsInfinitely => ExpirationDate.Equals(_unix_date);
 
-        public DateTime ExpirationDate {
-            get { return _expiration_date; }
-            set { _expiration_date = value; }
-        }
+        public DateTime ExpirationDate { get; set; } = _unix_date;
 
         public void MakeInfinitely() {
-            _expiration_date = _unix_date;
+            ExpirationDate = _unix_date;
         }
     }
 }

--- a/gpgme-sharp/PgpKey.cs
+++ b/gpgme-sharp/PgpKey.cs
@@ -289,8 +289,7 @@ namespace Libgpgme
                             throw new BadPassphraseException(_settings.passSettings.GetPassphraseInfo());
 
                         default:
-                            throw new GpgmeException("An unknown error occurred. Error: "
-                                + err.ToString(CultureInfo.InvariantCulture), err);
+                            throw GpgmeError.CreateException(errcode);
                     }
                 }
             }
@@ -408,8 +407,7 @@ namespace Libgpgme
                             throw new BadPassphraseException(_settings.passSettings.GetPassphraseInfo());
 
                         default:
-                            throw new GpgmeException("An unknown error occurred. Error: "
-                                + err.ToString(CultureInfo.InvariantCulture), err);
+                            throw GpgmeError.CreateException(errcode);
                     }
                 }
             }
@@ -473,7 +471,7 @@ namespace Libgpgme
                         throw new BadPassphraseException(_settings.passSettings.GetPassphraseInfo());
 
                     default:
-                        throw new GpgmeException("An unknown error occurred.", err);
+                        throw GpgmeError.CreateException(errcode);
                 }
             }
         }
@@ -534,7 +532,7 @@ namespace Libgpgme
                         throw new BadPassphraseException(_settings.passSettings.GetPassphraseInfo());
 
                     default:
-                        throw new GpgmeException("An unknown error occurred.", err);
+                        throw GpgmeError.CreateException(errcode);
                 }
             }
         }
@@ -568,7 +566,7 @@ namespace Libgpgme
                         throw new BadPassphraseException(_settings.passSettings.GetPassphraseInfo());
 
                     default:
-                        throw new GpgmeException("An unknown error occurred.", err);
+                        throw GpgmeError.CreateException(errcode);
                 }
             }
         }
@@ -735,8 +733,7 @@ namespace Libgpgme
                             throw new BadPassphraseException(_settings.passSettings.GetPassphraseInfo());
 
                         default:
-                            throw new GpgmeException("An unknown error occurred. Error: "
-                                + err.ToString(CultureInfo.InvariantCulture), err);
+                            throw GpgmeError.CreateException(errcode);
                     }
                 }
             }
@@ -830,8 +827,7 @@ namespace Libgpgme
                         case gpg_err_code_t.GPG_ERR_BAD_PASSPHRASE:
                             throw new BadPassphraseException(_settings.passSettings.GetPassphraseInfo());
                         default:
-                            throw new GpgmeException("An unknown error occurred. Error: "
-                                + err.ToString(CultureInfo.InvariantCulture), err);
+                            throw GpgmeError.CreateException(errcode);
                     }
                 }
             }
@@ -989,8 +985,7 @@ namespace Libgpgme
                         case gpg_err_code_t.GPG_ERR_BAD_PASSPHRASE:
                             throw new BadPassphraseException(_settings.passSettings.GetPassphraseInfo());
                         default:
-                            throw new GpgmeException("An unknown error occurred. Error: "
-                                + err.ToString(CultureInfo.InvariantCulture), err);
+                            throw GpgmeError.CreateException(errcode);
                     }
                 }
             }
@@ -1179,8 +1174,7 @@ namespace Libgpgme
                             if (options.missingpasswd && options.aborthandler) {
                                 throw new EmptyPassphraseException(_settings.passSettings.GetPassphraseInfo());
                             }
-                            throw new GpgmeException("An unknown error occurred. Error:"
-                                + err.ToString(CultureInfo.InvariantCulture), err);
+                            throw GpgmeError.CreateException(errcode);
                     }
                 }
             }

--- a/gpgme-sharp/PgpKey.cs
+++ b/gpgme-sharp/PgpKey.cs
@@ -19,20 +19,12 @@ namespace Libgpgme
             Expire // expire
         };
 
-        // Variables for key editing
-
-        // general key edit settings
-        private readonly Settings _settings;
-
-
         internal PgpKey(IntPtr keyPtr)
             : base(keyPtr) {
-            _settings = new Settings(this);
+            EditSettings = new Settings(this);
         }
 
-        public Settings EditSettings {
-            get { return _settings; }
-        }
+        public Settings EditSettings { get; private set; }
 
         protected override int KeyEditCallback(IntPtr handle, KeyEditStatusCode status, string args, int fd) {
             var op = (KeyEditOp) handle;
@@ -49,7 +41,7 @@ namespace Libgpgme
             if (op != KeyEditOp.Passphrase) {
                 switch (status) {
                     case KeyEditStatusCode.GoodPassphrase:
-                        _settings.passSettings.PassphrasePrevWasBad = false;
+                        EditSettings.passSettings.PassphrasePrevWasBad = false;
                         output = new byte[0];
                         runhandler = false;
                         break;
@@ -57,20 +49,20 @@ namespace Libgpgme
                 if (args != null) {
                     switch (status) {
                         case KeyEditStatusCode.UserIdHint:
-                            _settings.passSettings.PassphraseUserIdHint = args;
+                            EditSettings.passSettings.PassphraseUserIdHint = args;
                             output = new byte[0];
                             runhandler = false;
                             break;
 
                         case KeyEditStatusCode.NeedPassphrase:
-                            _settings.passSettings.PassphraseInfo = args;
+                            EditSettings.passSettings.PassphraseInfo = args;
                             output = new byte[0];
                             runhandler = false;
                             break;
 
                         case KeyEditStatusCode.MissingPassphrase:
                         case KeyEditStatusCode.BadPassphrase:
-                            _settings.passSettings.PassphrasePrevWasBad = true;
+                            EditSettings.passSettings.PassphrasePrevWasBad = true;
                             output = new byte[0];
                             runhandler = false;
                             break;
@@ -82,14 +74,14 @@ namespace Libgpgme
                                 /* "passphrase.enter" appears if the context has no passphrase 
                                  * callback function specified.
                                  */
-                                if (_settings.passSettings.PassphraseFunction != null && _settings.passSettings.PassphraseLastResult != PassphraseResult.Canceled) {
-                                    _settings.passSettings.PassphraseLastResult =
-                                        _settings.passSettings.PassphraseFunction(
+                                if (EditSettings.passSettings.PassphraseFunction != null && EditSettings.passSettings.PassphraseLastResult != PassphraseResult.Canceled) {
+                                    EditSettings.passSettings.PassphraseLastResult =
+                                        EditSettings.passSettings.PassphraseFunction(
                                             null,
                                             new PassphraseInfo(IntPtr.Zero,
-                                                _settings.passSettings.PassphraseUserIdHint,
-                                                _settings.passSettings.PassphraseInfo,
-                                                _settings.passSettings.PassphrasePrevWasBad),
+                                                EditSettings.passSettings.PassphraseUserIdHint,
+                                                EditSettings.passSettings.PassphraseInfo,
+                                                EditSettings.passSettings.PassphrasePrevWasBad),
                                             ref passphrase);
                                     if (passphrase != null) {
                                         byte[] p = Gpgme.ConvertCharArrayToUTF8(passphrase, 0);
@@ -104,9 +96,9 @@ namespace Libgpgme
                                             passphrase[i] = '\0';
                                         }
                                     }
-                                } else if (_settings.passSettings.Passphrase != null) {
+                                } else if (EditSettings.passSettings.Passphrase != null) {
                                     byte[] p = Gpgme.ConvertCharArrayToUTF8(
-                                        _settings.passSettings.Passphrase,
+                                        EditSettings.passSettings.Passphrase,
                                         0);
                                     libgpgme.NativeMethods.gpgme_io_write(fd, p, (UIntPtr)p.Length);
 
@@ -140,7 +132,7 @@ namespace Libgpgme
                         break;
                     case KeyEditOp.Passphrase:
                         output = PassphraseHandler(status, args, fd);
-                        if (output == null && _settings.passOptions.aborthandler) {
+                        if (output == null && EditSettings.passOptions.aborthandler) {
                             return 1; // abort
                         }
                         break;
@@ -200,7 +192,7 @@ namespace Libgpgme
 #endif
 
         private byte[] DeleteSignatureHandler(string args) {
-            PgpDeleteSignatureOptions delsig_options = _settings.delsigOptions;
+            PgpDeleteSignatureOptions delsig_options = EditSettings.delsigOptions;
 
             if (args != null) {
                 string output;
@@ -264,9 +256,9 @@ namespace Libgpgme
                 throw new ArgumentException("No signatures selected.");
             }
 
-            lock (_settings.passLock) {
-                lock (_settings.delsigLock) {
-                    _settings.delsigOptions = options;
+            lock (EditSettings.passLock) {
+                lock (EditSettings.delsigLock) {
+                    EditSettings.delsigOptions = options;
 
                     // reset object
                     options.cmdSend = false;
@@ -286,7 +278,7 @@ namespace Libgpgme
                         case gpg_err_code_t.GPG_ERR_NO_ERROR:
                             break;
                         case gpg_err_code_t.GPG_ERR_BAD_PASSPHRASE:
-                            throw new BadPassphraseException(_settings.passSettings.GetPassphraseInfo());
+                            throw new BadPassphraseException(EditSettings.passSettings.GetPassphraseInfo());
 
                         default:
                             throw GpgmeError.CreateException(errcode);
@@ -296,7 +288,7 @@ namespace Libgpgme
         }
 
         private byte[] RevokeSignatureHandler(string args) {
-            PgpRevokeSignatureOptions revsig_options = _settings.revsigOptions;
+            PgpRevokeSignatureOptions revsig_options = EditSettings.revsigOptions;
 
             if (args != null) {
                 // specify the uids from that the signature shall be revoked
@@ -377,9 +369,9 @@ namespace Libgpgme
                 throw new ArgumentException("No signatures selected.");
             }
 
-            lock (_settings.passLock) {
-                lock (_settings.revsigLock) {
-                    _settings.revsigOptions = options;
+            lock (EditSettings.passLock) {
+                lock (EditSettings.revsigLock) {
+                    EditSettings.revsigOptions = options;
 
                     // reset object
                     options.cmdSend = false;
@@ -404,7 +396,7 @@ namespace Libgpgme
                         case gpg_err_code_t.GPG_ERR_NO_ERROR:
                             break;
                         case gpg_err_code_t.GPG_ERR_BAD_PASSPHRASE:
-                            throw new BadPassphraseException(_settings.passSettings.GetPassphraseInfo());
+                            throw new BadPassphraseException(EditSettings.passSettings.GetPassphraseInfo());
 
                         default:
                             throw GpgmeError.CreateException(errcode);
@@ -414,7 +406,7 @@ namespace Libgpgme
         }
 
         private byte[] TrustHandler(string args) {
-            PgpTrustOptions trust_options = _settings.trustOptions;
+            PgpTrustOptions trust_options = EditSettings.trustOptions;
 
             if (args != null) {
                 string output;
@@ -450,8 +442,8 @@ namespace Libgpgme
                 throw new InvalidContextException("An invalid context has been supplied.");
             }
 
-            lock (_settings.trustLock) {
-                _settings.trustOptions = new PgpTrustOptions {
+            lock (EditSettings.trustLock) {
+                EditSettings.trustOptions = new PgpTrustOptions {
                     trust = trust
                 };
 
@@ -468,7 +460,7 @@ namespace Libgpgme
                     case gpg_err_code_t.GPG_ERR_NO_ERROR:
                         break;
                     case gpg_err_code_t.GPG_ERR_BAD_PASSPHRASE:
-                        throw new BadPassphraseException(_settings.passSettings.GetPassphraseInfo());
+                        throw new BadPassphraseException(EditSettings.passSettings.GetPassphraseInfo());
 
                     default:
                         throw GpgmeError.CreateException(errcode);
@@ -477,7 +469,7 @@ namespace Libgpgme
         }
 
         private byte[] EnableDisableHandler(string args) {
-            PgpEnableDisableOptions endis_options = _settings.endisOptions;
+            PgpEnableDisableOptions endis_options = EditSettings.endisOptions;
             string output = "";
 
             if (args != null) {
@@ -511,8 +503,8 @@ namespace Libgpgme
                 throw new InvalidContextException("An invalid context has been supplied.");
             }
 
-            lock (_settings.endisLock) {
-                _settings.endisOptions = new PgpEnableDisableOptions {
+            lock (EditSettings.endisLock) {
+                EditSettings.endisOptions = new PgpEnableDisableOptions {
                     OperationMode = PgpEnableDisableOptions.Mode.Enable
                 };
 
@@ -529,7 +521,7 @@ namespace Libgpgme
                     case gpg_err_code_t.GPG_ERR_NO_ERROR:
                         break;
                     case gpg_err_code_t.GPG_ERR_BAD_PASSPHRASE:
-                        throw new BadPassphraseException(_settings.passSettings.GetPassphraseInfo());
+                        throw new BadPassphraseException(EditSettings.passSettings.GetPassphraseInfo());
 
                     default:
                         throw GpgmeError.CreateException(errcode);
@@ -545,8 +537,8 @@ namespace Libgpgme
                 throw new InvalidContextException("An invalid context has been supplied.");
             }
 
-            lock (_settings.endisLock) {
-                _settings.endisOptions = new PgpEnableDisableOptions {
+            lock (EditSettings.endisLock) {
+                EditSettings.endisOptions = new PgpEnableDisableOptions {
                     OperationMode = PgpEnableDisableOptions.Mode.Disable
                 };
 
@@ -563,7 +555,7 @@ namespace Libgpgme
                     case gpg_err_code_t.GPG_ERR_NO_ERROR:
                         break;
                     case gpg_err_code_t.GPG_ERR_BAD_PASSPHRASE:
-                        throw new BadPassphraseException(_settings.passSettings.GetPassphraseInfo());
+                        throw new BadPassphraseException(EditSettings.passSettings.GetPassphraseInfo());
 
                     default:
                         throw GpgmeError.CreateException(errcode);
@@ -572,7 +564,7 @@ namespace Libgpgme
         }
 
         private byte[] SignHandler(KeyEditStatusCode status, string args) {
-            PgpSignatureOptions sig_options = _settings.sigOptions;
+            PgpSignatureOptions sig_options = EditSettings.sigOptions;
 
             if (args != null) {
                 if (status == KeyEditStatusCode.AlreadySigned) {
@@ -707,9 +699,9 @@ namespace Libgpgme
                 throw new ArgumentNullException("options", "No PgpSignatureOptions object specified.");
             }
 
-            lock (_settings.passLock) {
-                lock (_settings.sigLock) {
-                    _settings.sigOptions = options;
+            lock (EditSettings.passLock) {
+                lock (EditSettings.sigLock) {
+                    EditSettings.sigOptions = options;
 
                     // reset object
                     options.cmdSend = false;
@@ -730,7 +722,7 @@ namespace Libgpgme
                         case gpg_err_code_t.GPG_ERR_NO_ERROR:
                             break;
                         case gpg_err_code_t.GPG_ERR_BAD_PASSPHRASE:
-                            throw new BadPassphraseException(_settings.passSettings.GetPassphraseInfo());
+                            throw new BadPassphraseException(EditSettings.passSettings.GetPassphraseInfo());
 
                         default:
                             throw GpgmeError.CreateException(errcode);
@@ -741,7 +733,7 @@ namespace Libgpgme
 
 
         private byte[] ExpireHandler(string args) {
-            PgpExpirationOptions expire_options = _settings.expireOptions;
+            PgpExpirationOptions expire_options = EditSettings.expireOptions;
 
             if (args != null) {
                 string output;
@@ -805,9 +797,9 @@ namespace Libgpgme
                 throw new ArgumentNullException("options", "No PgpExpireOptions object specified.");
             }
 
-            lock (_settings.passLock) {
-                lock (_settings.expireLock) {
-                    _settings.expireOptions = options;
+            lock (EditSettings.passLock) {
+                lock (EditSettings.expireLock) {
+                    EditSettings.expireOptions = options;
 
                     // reset object
                     options.cmdSend = false;
@@ -825,7 +817,7 @@ namespace Libgpgme
                         case gpg_err_code_t.GPG_ERR_NO_ERROR:
                             break;
                         case gpg_err_code_t.GPG_ERR_BAD_PASSPHRASE:
-                            throw new BadPassphraseException(_settings.passSettings.GetPassphraseInfo());
+                            throw new BadPassphraseException(EditSettings.passSettings.GetPassphraseInfo());
                         default:
                             throw GpgmeError.CreateException(errcode);
                     }
@@ -838,7 +830,7 @@ namespace Libgpgme
 			DebugOutput("Inside AddSubkeyHandler(..)");
 #endif
 
-            PgpSubkeyOptions subkey_options = _settings.subkeyOptions;
+            PgpSubkeyOptions subkey_options = EditSettings.subkeyOptions;
 
             if (args != null) {
                 string output;
@@ -857,12 +849,12 @@ namespace Libgpgme
                      * in order to specify customized DSA or RSA subkeys.
                      */
 
-                    _settings.subkeyalgoquestion++;
+                    EditSettings.subkeyalgoquestion++;
 
                     output = ((int) subkey_options.Algorithm).ToString(CultureInfo.InvariantCulture);
 
                     // GPG IS NOT IN EXPERT MODE!
-                    if (_settings.subkeyalgoquestion > 1) {
+                    if (EditSettings.subkeyalgoquestion > 1) {
 #if (VERBOSE_DEBUG)
 						DebugOutput("End keygen.algo.");
 #endif
@@ -877,23 +869,23 @@ namespace Libgpgme
                 if (args.Equals("keygen.flags")) {
                     // Auth is NOT enabled by default
                     if ((subkey_options.Capability & AlgorithmCapability.CanAuth) == AlgorithmCapability.CanAuth &&
-                        ((_settings.subkeycapability & AlgorithmCapability.CanAuth) != AlgorithmCapability.CanAuth)) {
-                        _settings.subkeycapability |= AlgorithmCapability.CanAuth;
+                        ((EditSettings.subkeycapability & AlgorithmCapability.CanAuth) != AlgorithmCapability.CanAuth)) {
+                        EditSettings.subkeycapability |= AlgorithmCapability.CanAuth;
                         output = "A";
                     }
                         // Sign is enabled by default!
                     else if ((subkey_options.Capability & AlgorithmCapability.CanSign) != AlgorithmCapability.CanSign &&
-                        ((_settings.subkeycapability & AlgorithmCapability.CanSign) != AlgorithmCapability.CanSign)) {
-                        _settings.subkeycapability |= AlgorithmCapability.CanSign;
+                        ((EditSettings.subkeycapability & AlgorithmCapability.CanSign) != AlgorithmCapability.CanSign)) {
+                        EditSettings.subkeycapability |= AlgorithmCapability.CanSign;
                         // save, that we have checked "Sign" flag
                         output = "S";
                     }
                         // Encrypt is enabled by default!
                     else if ((subkey_options.Capability & AlgorithmCapability.CanEncrypt) !=
                         AlgorithmCapability.CanEncrypt &&
-                            ((_settings.subkeycapability & AlgorithmCapability.CanEncrypt) !=
+                            ((EditSettings.subkeycapability & AlgorithmCapability.CanEncrypt) !=
                                 AlgorithmCapability.CanEncrypt)) {
-                        _settings.subkeycapability |= AlgorithmCapability.CanEncrypt;
+                        EditSettings.subkeycapability |= AlgorithmCapability.CanEncrypt;
                         // save, that we have checked "Encrypt" flag
                         output = "E";
                     } else {
@@ -927,7 +919,7 @@ namespace Libgpgme
                     return ToU8(output);
                 }
                 if (args.Equals("keyedit.prompt")) {
-                    if (_settings.subkeyalgoquestion > 1) {
+                    if (EditSettings.subkeyalgoquestion > 1) {
                         /* Do not save the new created subkey because the user 
                          * requested a customized subkey but GnuPG was not in 
                          * "Expert" mode.
@@ -963,11 +955,11 @@ namespace Libgpgme
                 throw new ArgumentNullException("options", "No PgpSubkeyOptions object specified.");
             }
 
-            lock (_settings.passLock) {
-                lock (_settings.subkeyLock) {
-                    _settings.subkeyOptions = options;
-                    _settings.subkeycapability = AlgorithmCapability.CanNothing;
-                    _settings.subkeyalgoquestion = 0;
+            lock (EditSettings.passLock) {
+                lock (EditSettings.subkeyLock) {
+                    EditSettings.subkeyOptions = options;
+                    EditSettings.subkeycapability = AlgorithmCapability.CanNothing;
+                    EditSettings.subkeyalgoquestion = 0;
                     options.cmdSend = false;
 
                     const KeyEditOp OP = KeyEditOp.AddSubkey;
@@ -977,13 +969,13 @@ namespace Libgpgme
                     gpg_err_code_t errcode = libgpgerror.gpg_err_code(err);
                     switch (errcode) {
                         case gpg_err_code_t.GPG_ERR_NO_ERROR:
-                            if (_settings.subkeyalgoquestion > 1) {
+                            if (EditSettings.subkeyalgoquestion > 1) {
                                 throw new NotSupportedException(
                                     "GnuPG was not in expert mode. Customized subkeys are not supported.");
                             }
                             break;
                         case gpg_err_code_t.GPG_ERR_BAD_PASSPHRASE:
-                            throw new BadPassphraseException(_settings.passSettings.GetPassphraseInfo());
+                            throw new BadPassphraseException(EditSettings.passSettings.GetPassphraseInfo());
                         default:
                             throw GpgmeError.CreateException(errcode);
                     }
@@ -992,7 +984,7 @@ namespace Libgpgme
         }
 
         private byte[] PassphraseHandler(KeyEditStatusCode status, string args, int fd) {
-            PgpPassphraseOptions pass_options = _settings.passOptions;
+            PgpPassphraseOptions pass_options = EditSettings.passOptions;
 
             switch (status) {
                 case KeyEditStatusCode.MissingPassphrase:
@@ -1036,16 +1028,16 @@ namespace Libgpgme
 
                 switch (status) {
                     case KeyEditStatusCode.UserIdHint:
-                        _settings.passSettings.PassphraseUserIdHint = args;
+                        EditSettings.passSettings.PassphraseUserIdHint = args;
                         return new byte[0];
 
                     case KeyEditStatusCode.NeedPassphrase:
-                        _settings.passSettings.PassphraseInfo = args;
+                        EditSettings.passSettings.PassphraseInfo = args;
                         return new byte[0];
 
                     case KeyEditStatusCode.MissingPassphrase:
                     case KeyEditStatusCode.BadPassphrase:
-                        _settings.passSettings.PassphrasePrevWasBad = true;
+                        EditSettings.passSettings.PassphrasePrevWasBad = true;
                         return new byte[0];
 
                     case KeyEditStatusCode.GetHidden:
@@ -1075,18 +1067,18 @@ namespace Libgpgme
                                 }
                             }
 
-                            if (passphrase_func != null && _settings.passSettings.PassphraseLastResult != PassphraseResult.Canceled) {
+                            if (passphrase_func != null && EditSettings.passSettings.PassphraseLastResult != PassphraseResult.Canceled) {
 #if (VERBOSE_DEBUG)
 								    DebugOutput("Calling passphrase callback function.. ");
 #endif
                                 // run callback function
-                                _settings.passSettings.PassphraseLastResult =
+                                EditSettings.passSettings.PassphraseLastResult =
                                     passphrase_func(
                                         null,
                                         new PassphraseInfo(IntPtr.Zero,
-                                            _settings.passSettings.PassphraseUserIdHint,
-                                            _settings.passSettings.PassphraseInfo,
-                                            _settings.passSettings.PassphrasePrevWasBad),
+                                            EditSettings.passSettings.PassphraseUserIdHint,
+                                            EditSettings.passSettings.PassphraseInfo,
+                                            EditSettings.passSettings.PassphrasePrevWasBad),
                                         ref passphrase);
                             }
 
@@ -1138,11 +1130,11 @@ namespace Libgpgme
                 throw new ArgumentNullException("options", "PgpPassphraseOptions object required.");
             }
 
-            lock (_settings.passLock) {
-                lock (_settings.newpassLock) {
+            lock (EditSettings.passLock) {
+                lock (EditSettings.newpassLock) {
                     // specify key edit operation;
                     const KeyEditOp OP = KeyEditOp.Passphrase;
-                    _settings.passOptions = options;
+                    EditSettings.passOptions = options;
 
                     // reset object
                     options.passphraseSendCmd = false;
@@ -1169,10 +1161,10 @@ namespace Libgpgme
                             {
                                 break;
                             }
-                            throw new BadPassphraseException(_settings.passSettings.GetPassphraseInfo());
+                            throw new BadPassphraseException(EditSettings.passSettings.GetPassphraseInfo());
                         default:
                             if (options.missingpasswd && options.aborthandler) {
-                                throw new EmptyPassphraseException(_settings.passSettings.GetPassphraseInfo());
+                                throw new EmptyPassphraseException(EditSettings.passSettings.GetPassphraseInfo());
                             }
                             throw GpgmeError.CreateException(errcode);
                     }

--- a/gpgme-sharp/PgpSignatureOptions.cs
+++ b/gpgme-sharp/PgpSignatureOptions.cs
@@ -22,7 +22,7 @@ namespace Libgpgme
         internal bool signAllUids = true;
 
         public int TrustDepth {
-            get { return _trustdepth; }
+            get => _trustdepth;
             set {
                 if (value > 0) {
                     _trustdepth = value;
@@ -33,7 +33,7 @@ namespace Libgpgme
         }
 
         public bool IsInfinitely {
-            get { return ExpirationDate.Equals(_unix_date); }
+            get => ExpirationDate.Equals(_unix_date);
             set {
                 if (value) {
                     ExpirationDate = _unix_date;

--- a/gpgme-sharp/PgpSubkeyOptions.cs
+++ b/gpgme-sharp/PgpSubkeyOptions.cs
@@ -22,9 +22,7 @@ namespace Libgpgme
             KeyLength = KEY_LENGTH_2048;
         }
 
-        public bool IsInfinitely {
-            get { return ExpirationDate.Equals(_unix_date); }
-        }
+        public bool IsInfinitely => ExpirationDate.Equals(_unix_date);
 
         public void MakeInfinitely() {
             ExpirationDate = _unix_date;

--- a/gpgme-sharp/Recipient.cs
+++ b/gpgme-sharp/Recipient.cs
@@ -8,9 +8,6 @@ namespace Libgpgme
 {
     public class Recipient : IEnumerable<Recipient>
     {
-        private string _keyid;
-        private Recipient _next;
-        private KeyAlgorithm _pubkey_algo;
         private int _status;
 
         internal Recipient(IntPtr recpPtr) {
@@ -21,19 +18,14 @@ namespace Libgpgme
             UpdateFromMem(recpPtr);
         }
 
-        public string KeyId {
-            get { return _keyid; }
-        }
-        public KeyAlgorithm KeyAlgorithm {
-            get { return _pubkey_algo; }
-        }
+        public string KeyId { get; private set; }
 
-        public int Status {
-            get { return _status; }
-        }
-        public Recipient Next {
-            get { return _next; }
-        }
+        public KeyAlgorithm KeyAlgorithm { get; private set; }
+
+        public int Status => _status;
+
+        public Recipient Next { get; private set; }
+
         #region IEnumerable<Recipient> Members
 
         public IEnumerator<Recipient> GetEnumerator() {
@@ -53,12 +45,12 @@ namespace Libgpgme
             var recp = new _gpgme_recipient();
             Marshal.PtrToStructure(recpPtr, recp);
 
-            _keyid = Gpgme.PtrToStringUTF8(recp.keyid);
-            _pubkey_algo = (KeyAlgorithm) recp.pubkey_algo;
+            KeyId = Gpgme.PtrToStringUTF8(recp.keyid);
+            KeyAlgorithm = (KeyAlgorithm) recp.pubkey_algo;
             _status = recp.status;
 
             if (recp.next != IntPtr.Zero) {
-                _next = new Recipient(recp.next);
+                Next = new Recipient(recp.next);
             }
         }
     }

--- a/gpgme-sharp/Signature.cs
+++ b/gpgme-sharp/Signature.cs
@@ -8,23 +8,10 @@ namespace Libgpgme
 {
     public class Signature : IEnumerable<Signature>
     {
-        private bool _chain_model;
         private UIntPtr _exp_timestamp;
-        private string _fpr;
-        private HashAlgorithm _hash_algo;
-        private Signature _next;
-        private SignatureNotation _notations; // gpgme_sig_notation_t
-        private string _pka_address; // char *
-        private PkaStatus _pka_trust;
-        private KeyAlgorithm _pubkey_algo;
         private uint _status; //gpgme_error_t
-
-        /* A summary of the signature status.  */
-        private SignatureSummary _summary;
         private UIntPtr _timestamp;
-        private Validity _validity;
         private uint _validity_reason; //gpgme_error_t
-        private bool _wrong_key_usage;
 
         internal Signature(IntPtr sigPtr) {
             if (sigPtr == IntPtr.Zero) {
@@ -34,77 +21,47 @@ namespace Libgpgme
             UpdateFromMem(sigPtr);
         }
 
-        public Signature Next {
-            get { return _next; }
-        }
+        public Signature Next { get; private set; }
 
-        public SignatureSummary Summary {
-            get { return _summary; }
-        }
+        public SignatureSummary Summary { get; private set; }
 
         /* The fingerprint or key ID of the signature.  */
-        public string Fingerprint {
-            get { return _fpr; }
-        }
+        public string Fingerprint { get; private set; }
 
         /* The status of the signature.  */
-        public long Status {
-            get { return _status; }
-        }
+        public long Status => _status;
 
         /* Notation data and policy URLs.  */
-        public SignatureNotation Notations {
-            get { return _notations; }
-        }
+        public SignatureNotation Notations { get; private set; }
 
         /* Signature creation time.  */
-        public Validity Validity {
-            get { return _validity; }
-        }
+        public Validity Validity { get; private set; }
 
-        public long ValidityReason {
-            get { return _validity_reason; }
-        }
+        public long ValidityReason => _validity_reason;
 
         /* The public key algorithm used to create the signature.  */
-        public KeyAlgorithm PubkeyAlgorithm {
-            get { return _pubkey_algo; }
-        }
+        public KeyAlgorithm PubkeyAlgorithm { get; private set; }
 
         /* The hash algorithm used to create the signature.  */
-        public HashAlgorithm HashAlgorithm {
-            get { return _hash_algo; }
-        }
+        public HashAlgorithm HashAlgorithm { get; private set; }
 
         /* The mailbox from the PKA information or NULL. */
-        public string PKAAddress {
-            get { return _pka_address; }
-        }
+        public string PKAAddress { get; private set; }
 
-        public bool WrongKeyUsage {
-            get { return _wrong_key_usage; }
-        }
+        public bool WrongKeyUsage { get; private set; }
 
-        public PkaStatus PKATrust {
-            get { return _pka_trust; }
-        }
+        public PkaStatus PKATrust { get; private set; }
 
-        public bool ChainModel {
-            get { return _chain_model; }
-        }
+        public bool ChainModel { get; private set; }
 
-        public DateTime Timestamp {
-            get { return Gpgme.ConvertFromUnix((long) _timestamp); }
-        }
-        public DateTime TimestampUTC {
-            get { return Gpgme.ConvertFromUnixUTC((long) _timestamp); }
-        }
-        public DateTime ExpTimestamp {
-            get { return Gpgme.ConvertFromUnix((long) _exp_timestamp); }
-        }
-        public DateTime ExpTimestampUTC {
-            get { return Gpgme.ConvertFromUnixUTC((long) _exp_timestamp); }
-        }
+        public DateTime Timestamp => Gpgme.ConvertFromUnix((long) _timestamp);
+
+        public DateTime TimestampUTC => Gpgme.ConvertFromUnixUTC((long) _timestamp);
+
+        public DateTime ExpTimestamp => Gpgme.ConvertFromUnix((long) _exp_timestamp);
+
+        public DateTime ExpTimestampUTC => Gpgme.ConvertFromUnixUTC((long) _exp_timestamp);
+
         #region IEnumerable<Signature> Members
 
         IEnumerator IEnumerable.GetEnumerator() {
@@ -133,51 +90,51 @@ namespace Libgpgme
                 var unixsig = new _gpgme_signature();
                 Marshal.PtrToStructure(sigPtr, unixsig);
 
-                _summary = (SignatureSummary) unixsig.summary;
-                _fpr = Gpgme.PtrToStringUTF8(unixsig.fpr);
+                Summary = (SignatureSummary) unixsig.summary;
+                Fingerprint = Gpgme.PtrToStringUTF8(unixsig.fpr);
                 _status = unixsig.status;
                 _timestamp = unixsig.timestamp;
                 _exp_timestamp = unixsig.exp_timestamp;
-                _validity = (Validity) unixsig.validity;
+                Validity = (Validity) unixsig.validity;
                 _validity_reason = unixsig.validity_reason;
-                _pubkey_algo = (KeyAlgorithm) unixsig.pubkey_algo;
-                _hash_algo = (HashAlgorithm) unixsig.hash_algo;
-                _pka_address = Gpgme.PtrToStringUTF8(unixsig.pka_address);
-                _wrong_key_usage = unixsig.wrong_key_usage;
-                _pka_trust = unixsig.pka_trust;
-                _chain_model = unixsig.chain_model;
+                PubkeyAlgorithm = (KeyAlgorithm) unixsig.pubkey_algo;
+                HashAlgorithm = (HashAlgorithm) unixsig.hash_algo;
+                PKAAddress = Gpgme.PtrToStringUTF8(unixsig.pka_address);
+                WrongKeyUsage = unixsig.wrong_key_usage;
+                PKATrust = unixsig.pka_trust;
+                ChainModel = unixsig.chain_model;
 
                 if (unixsig.notations != IntPtr.Zero) {
-                    _notations = new SignatureNotation(unixsig.notations);
+                    Notations = new SignatureNotation(unixsig.notations);
                 }
 
                 if (unixsig.next != IntPtr.Zero) {
-                    _next = new Signature(unixsig.next);
+                    Next = new Signature(unixsig.next);
                 }
             } else {
                 var winsig = new _gpgme_signature_windows();
                 Marshal.PtrToStructure(sigPtr, winsig);
 
-                _summary = (SignatureSummary) winsig.summary;
-                _fpr = Gpgme.PtrToStringUTF8(winsig.fpr);
+                Summary = (SignatureSummary) winsig.summary;
+                Fingerprint = Gpgme.PtrToStringUTF8(winsig.fpr);
                 _status = winsig.status;
                 _timestamp = winsig.timestamp;
                 _exp_timestamp = winsig.exp_timestamp;
-                _validity = (Validity) winsig.validity;
+                Validity = (Validity) winsig.validity;
                 _validity_reason = winsig.validity_reason;
-                _pubkey_algo = (KeyAlgorithm) winsig.pubkey_algo;
-                _hash_algo = (HashAlgorithm) winsig.hash_algo;
-                _pka_address = Gpgme.PtrToStringUTF8(winsig.pka_address);
-                _wrong_key_usage = winsig.wrong_key_usage;
-                _pka_trust = winsig.pka_trust;
-                _chain_model = winsig.chain_model;
+                PubkeyAlgorithm = (KeyAlgorithm) winsig.pubkey_algo;
+                HashAlgorithm = (HashAlgorithm) winsig.hash_algo;
+                PKAAddress = Gpgme.PtrToStringUTF8(winsig.pka_address);
+                WrongKeyUsage = winsig.wrong_key_usage;
+                PKATrust = winsig.pka_trust;
+                ChainModel = winsig.chain_model;
 
                 if (winsig.notations != IntPtr.Zero) {
-                    _notations = new SignatureNotation(winsig.notations);
+                    Notations = new SignatureNotation(winsig.notations);
                 }
 
                 if (winsig.next != IntPtr.Zero) {
-                    _next = new Signature(winsig.next);
+                    Next = new Signature(winsig.next);
                 }
             }
         }

--- a/gpgme-sharp/SignatureNotation.cs
+++ b/gpgme-sharp/SignatureNotation.cs
@@ -8,10 +8,7 @@ namespace Libgpgme
 {
     public class SignatureNotation : IEnumerable<SignatureNotation>
     {
-        private string _name, _value;
-        private bool _critical;
-        private SignatureNotationFlags _flags;
-        private bool _human_readable;
+        private string _value;
         private SignatureNotation _next;
 
         internal SignatureNotation(IntPtr signotPtr) {
@@ -23,24 +20,18 @@ namespace Libgpgme
             UpdateFromMem(signotPtr);
         }
 
-        public SignatureNotation Next {
-            get { return _next; }
-        }
-        public bool Critical {
-            get { return _critical; }
-        }
-        public bool HumanReadable {
-            get { return _human_readable; }
-        }
-        public string Value {
-            get { return _value; }
-        }
-        public string Name {
-            get { return _name; }
-        }
-        public SignatureNotationFlags Flags {
-            get { return _flags; }
-        }
+        public SignatureNotation Next => _next;
+
+        public bool Critical { get; private set; }
+
+        public bool HumanReadable { get; private set; }
+
+        public string Value => _value;
+
+        public string Name { get; private set; }
+
+        public SignatureNotationFlags Flags { get; private set; }
+
         #region IEnumerable<SignatureNotation> Members
 
         IEnumerator IEnumerable.GetEnumerator() {
@@ -68,13 +59,13 @@ namespace Libgpgme
             }
             if (signot.name != IntPtr.Zero) {
                 len = signot.name_len;
-                _name = Gpgme.PtrToStringUTF8(signot.name,
+                Name = Gpgme.PtrToStringUTF8(signot.name,
                     len);
             }
 
-            _flags = (SignatureNotationFlags) signot.flags;
-            _critical = signot.critical;
-            _human_readable = signot.human_readable;
+            Flags = (SignatureNotationFlags) signot.flags;
+            Critical = signot.critical;
+            HumanReadable = signot.human_readable;
 
             if (signot.next != IntPtr.Zero) {
                 _next = new SignatureNotation(signot.next);

--- a/gpgme-sharp/SignatureResult.cs
+++ b/gpgme-sharp/SignatureResult.cs
@@ -6,8 +6,6 @@ namespace Libgpgme
 {
     public class SignatureResult
     {
-        /* The list of invalid signers.  */
-        private InvalidKey _invalid_signers;
         private NewSignature _signatures;
 
         internal SignatureResult(IntPtr sigrstPtr) {
@@ -17,19 +15,16 @@ namespace Libgpgme
             UpdateFromMem(sigrstPtr);
         }
 
-        public InvalidKey InvalidSigners {
-            get { return _invalid_signers; }
-        }
-        public NewSignature Signatures {
-            get { return _signatures; }
-        }
+        public InvalidKey InvalidSigners { get; private set; }
+
+        public NewSignature Signatures => _signatures;
 
         private void UpdateFromMem(IntPtr sigrstPtr) {
             var rst = new _gpgme_op_sign_result();
             Marshal.PtrToStructure(sigrstPtr, rst);
 
             if (!rst.invalid_signers.Equals(IntPtr.Zero)) {
-                _invalid_signers = new InvalidKey(rst.invalid_signers);
+                InvalidSigners = new InvalidKey(rst.invalid_signers);
             }
 
             if (!rst.signatures.Equals(IntPtr.Zero)) {

--- a/gpgme-sharp/Subkey.cs
+++ b/gpgme-sharp/Subkey.cs
@@ -58,16 +58,13 @@ namespace Libgpgme
             }
         }
 
-        public DateTime Expires {
-            get { return Gpgme.ConvertFromUnix(_expires); }
-        }
-        public DateTime ExpiresUTC {
-            get { return Gpgme.ConvertFromUnixUTC(_expires); }
-        }
+        public DateTime Expires => Gpgme.ConvertFromUnix(_expires);
+
+        public DateTime ExpiresUTC => Gpgme.ConvertFromUnixUTC(_expires);
 
         public bool IsInfinitely {
-            get { return _expires == 0; }
-            set { throw new NotImplementedException(); }
+            get => _expires == 0;
+            set => throw new NotImplementedException();
         }
 
         #region IEnumerable<Subkey> Members


### PR DESCRIPTION
A few code cleanups.

Automated:
 - Use [expression-bodied members](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/statements-expressions-operators/expression-bodied-members)
 - Use auto properties rather than manual getters and setters

Manual changes:
 - Generalise error handling code. Create a static `GpgmeError.Check` method that throws on errors, rather than every method having to manually check the error code itself
 - Remove unused constants from `Context`
 - Add `EnsureValid` method to `Context`, rather than having to wrap every method in an `if (IsValid) {` block