### PR TITLE
Add export modes and example for export

### DIFF
--- a/Examples/KeyOperations/ExportKey/ExportKey.csproj
+++ b/Examples/KeyOperations/ExportKey/ExportKey.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\gpgme-sharp\gpgme-sharp.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Properties\" />
+  </ItemGroup>
+
+</Project>

--- a/Examples/KeyOperations/ExportKey/Program.cs
+++ b/Examples/KeyOperations/ExportKey/Program.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.IO;
+using Libgpgme;
+
+namespace ExportKey
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            const string keyToExport = "A3E1D41E632142737E3EDC340E6B9269F9F982C1!";
+
+            using (var ctx = new Context())
+            {
+                ctx.Armor = true;
+                ctx.KeyStore.Export(keyToExport, "exported.pub");
+                Console.WriteLine($"Exported public key {keyToExport} to exported.pub");
+
+                ctx.KeyStore.Export(keyToExport, "exported.gpg", ExportMode.Secret);
+                Console.WriteLine($"Exported private key {keyToExport} (if available) to exported.gpg");
+            }
+        }
+    }
+}

--- a/Examples/KeyOperations/ExportKey/Properties/launchSettings.json
+++ b/Examples/KeyOperations/ExportKey/Properties/launchSettings.json
@@ -1,0 +1,10 @@
+{
+  "profiles": {
+    "ExportKey": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "GPGME_DEBUG": "0"
+      }
+    }
+  }
+}

--- a/GPGME.Native.Shared/Enums.cs
+++ b/GPGME.Native.Shared/Enums.cs
@@ -409,4 +409,51 @@ namespace Libgpgme
         /// </summary>
         Loopback = gpgme_pinentry_mode_t.GPGME_PINENTRY_MODE_LOOPBACK,
     }
+
+    [Flags]
+    public enum ExportMode
+    {
+        /// <summary>
+        /// If this bit is set, the output is send directly to the default keyserver. This is
+        /// currently only allowed for OpenPGP keys. It is good practise to not send more than
+        /// a few dozens key to a keyserver at one time. Using this flag requires that the
+        /// keydata argument of the export function is set to NULL. 
+        /// </summary>
+        Extern = gpgme_export_mode_t.GPGME_EXPORT_MODE_EXTERN,
+
+        /// <summary>
+        /// If this bit is set, the smallest possible key is exported. For OpenPGP keys it removes
+        /// all signatures except for the latest self-signatures. For X.509 keys it has no effect.
+        /// Since: 1.3.1
+        /// </summary>
+        Minimal = gpgme_export_mode_t.GPGME_EXPORT_MODE_MINIMAL,
+
+        /// <summary>
+        /// Instead of exporting the public key, the secret key is exported. This may not be
+        /// combined with GPGME_EXPORT_MODE_EXTERN. For X.509 the export format is PKCS#8.
+        /// Since: 1.6.0
+        /// </summary>
+        Secret = gpgme_export_mode_t.GPGME_EXPORT_MODE_SECRET,
+
+        /// <summary>
+        /// If this flag is used with GPGME_EXPORT_MODE_SECRET for an X.509 key the export
+        /// format will be changed to PKCS#1. This flag may not be used with OpenPGP.
+        /// Since: 1.6.0
+        /// </summary>
+        Raw = gpgme_export_mode_t.GPGME_EXPORT_MODE_RAW,
+
+        /// <summary>
+        /// If this flag is used with GPGME_EXPORT_MODE_SECRET for an X.509 key the export
+        /// format will be changed to PKCS#12 which also includes the certificate. This flag
+        /// may not be used with OpenPGP.
+        /// Since: 1.6.0
+        /// </summary>
+        Pkcs12 = gpgme_export_mode_t.GPGME_EXPORT_MODE_PKCS12,
+
+        /// <summary>
+        /// Experimental. Do not export user ids. Works only with certain gpg version.
+        /// Since: 1.12.0
+        /// </summary>
+        NoUID = gpgme_export_mode_t.GPGME_EXPORT_MODE_NOUID,
+    }
 }

--- a/GPGME.Native.Shared/libgpgme_Enums.cs
+++ b/GPGME.Native.Shared/libgpgme_Enums.cs
@@ -353,4 +353,51 @@ namespace Libgpgme.Interop
         /// </summary>
         GPGME_PINENTRY_MODE_LOOPBACK
     }
+
+    [Flags]
+    public enum gpgme_export_mode_t
+    {
+        /// <summary>
+        /// If this bit is set, the output is send directly to the default keyserver. This is
+        /// currently only allowed for OpenPGP keys. It is good practise to not send more than
+        /// a few dozens key to a keyserver at one time. Using this flag requires that the
+        /// keydata argument of the export function is set to NULL. 
+        /// </summary>
+        GPGME_EXPORT_MODE_EXTERN = 2,
+
+        /// <summary>
+        /// If this bit is set, the smallest possible key is exported. For OpenPGP keys it removes
+        /// all signatures except for the latest self-signatures. For X.509 keys it has no effect.
+        /// Since: 1.3.1
+        /// </summary>
+        GPGME_EXPORT_MODE_MINIMAL = 4,
+
+        /// <summary>
+        /// Instead of exporting the public key, the secret key is exported. This may not be
+        /// combined with GPGME_EXPORT_MODE_EXTERN. For X.509 the export format is PKCS#8.
+        /// Since: 1.6.0
+        /// </summary>
+        GPGME_EXPORT_MODE_SECRET = 16,
+
+        /// <summary>
+        /// If this flag is used with GPGME_EXPORT_MODE_SECRET for an X.509 key the export
+        /// format will be changed to PKCS#1. This flag may not be used with OpenPGP.
+        /// Since: 1.6.0
+        /// </summary>
+        GPGME_EXPORT_MODE_RAW = 32,
+
+        /// <summary>
+        /// If this flag is used with GPGME_EXPORT_MODE_SECRET for an X.509 key the export
+        /// format will be changed to PKCS#12 which also includes the certificate. This flag
+        /// may not be used with OpenPGP.
+        /// Since: 1.6.0
+        /// </summary>
+        GPGME_EXPORT_MODE_PKCS12 = 64,
+
+        /// <summary>
+        /// Experimental. Do not export user ids. Works only with certain gpg version.
+        /// Since: 1.12.0
+        /// </summary>
+        GPGME_EXPORT_MODE_NOUID = 128,
+    }
 }

--- a/GPGME.Native.Win32/NativeMethods.cs
+++ b/GPGME.Native.Win32/NativeMethods.cs
@@ -382,14 +382,14 @@ namespace GPGME.Native.Unix
         internal static extern int gpgme_op_export(
             [In] IntPtr ctx,
             [In] IntPtr pattern, // const char*
-            [In] uint reserved,
+            [In] uint mode,
             [In] IntPtr keydata);
 
         [DllImport(LIBRARY_NAME, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int gpgme_op_export_ext(
             [In] IntPtr ctx,
             [In] IntPtr[] pattern, //const char *pattern[]
-            [In] uint reserved,
+            [In] uint mode,
             [In] IntPtr keydata);
 
         /* Create a new data buffer and return it in R_DH.  */

--- a/gpgme-sharp.sln
+++ b/gpgme-sharp.sln
@@ -7,35 +7,37 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "gpgme-sharp", "gpgme-sharp\
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Examples", "Examples", "{F803B37B-3E35-43F8-A772-3A6D0ECB610A}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CreatePgpKey", "Examples\CreatePgpKey\CreatePgpKey.csproj", "{81E13A5A-2BF9-4EFB-9AC8-FB004703B648}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CreatePgpKey", "Examples\CreatePgpKey\CreatePgpKey.csproj", "{81E13A5A-2BF9-4EFB-9AC8-FB004703B648}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "DataBufferSamples", "DataBufferSamples", "{040ADE11-7491-4C7C-9A4B-E4B645F08BD5}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DataBufferTest", "Examples\DataBufferSamples\DataBufferTest\DataBufferTest.csproj", "{478F350D-4A32-4B68-BC3E-EC913CD097CF}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DataBufferTest", "Examples\DataBufferSamples\DataBufferTest\DataBufferTest.csproj", "{478F350D-4A32-4B68-BC3E-EC913CD097CF}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "KeyOperations", "KeyOperations", "{34B6A704-4985-40D1-8D8D-09C4C97227EA}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ImportKey", "Examples\KeyOperations\ImportKey\ImportKey.csproj", "{E5A0AC77-765C-4E26-ADA1-C19D0B0D2745}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ImportKey", "Examples\KeyOperations\ImportKey\ImportKey.csproj", "{E5A0AC77-765C-4E26-ADA1-C19D0B0D2745}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ImportKey2", "Examples\KeyOperations\ImportKey2\ImportKey2.csproj", "{4A57F975-5C75-4454-933D-5F3EA8958D90}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ImportKey2", "Examples\KeyOperations\ImportKey2\ImportKey2.csproj", "{4A57F975-5C75-4454-933D-5F3EA8958D90}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ListKeys", "Examples\KeyOperations\ListKeys\ListKeys.csproj", "{6BACB1D8-F407-4701-86D3-323C878B0C31}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ListKeys", "Examples\KeyOperations\ListKeys\ListKeys.csproj", "{6BACB1D8-F407-4701-86D3-323C878B0C31}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModifyPgpKey", "Examples\ModifyPgpKey\ModifyPgpKey.csproj", "{EAD627D1-7102-48BA-AA28-1F0E5B28876E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ModifyPgpKey", "Examples\ModifyPgpKey\ModifyPgpKey.csproj", "{EAD627D1-7102-48BA-AA28-1F0E5B28876E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PgpCombinedCrypto", "Examples\PgpCombinedCrypto\PgpCombinedCrypto.csproj", "{B4DC5583-0F25-4451-A15E-171CE7583D3E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PgpCombinedCrypto", "Examples\PgpCombinedCrypto\PgpCombinedCrypto.csproj", "{B4DC5583-0F25-4451-A15E-171CE7583D3E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PgpEncryptDecrypt", "Examples\PgpEncryptDecrypt\PgpEncryptDecrypt.csproj", "{CA80E147-9549-483F-AC09-57A46891BBC2}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PgpEncryptDecrypt", "Examples\PgpEncryptDecrypt\PgpEncryptDecrypt.csproj", "{CA80E147-9549-483F-AC09-57A46891BBC2}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PgpSignVerify", "Examples\PgpSignVerify\PgpSignVerify.csproj", "{F593613E-08BF-4B4C-A863-4FFD631E369B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PgpSignVerify", "Examples\PgpSignVerify\PgpSignVerify.csproj", "{F593613E-08BF-4B4C-A863-4FFD631E369B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SignPgpKey", "Examples\SignPgpKey\SignPgpKey.csproj", "{B2B6890B-54C8-4BA7-AE61-F06E582A6A3C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SignPgpKey", "Examples\SignPgpKey\SignPgpKey.csproj", "{B2B6890B-54C8-4BA7-AE61-F06E582A6A3C}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GPGME.Native.Win32", "GPGME.Native.Win32\GPGME.Native.Win32.csproj", "{601F32CB-CF0D-486B-848F-8A07BA42658F}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GPGME.Native.Unix", "GPGME.Native.Unix\GPGME.Native.Unix.csproj", "{3001DC3D-E42D-4DD1-8960-32A9580FA94D}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GPGME.Native.Shared", "GPGME.Native.Shared\GPGME.Native.Shared.csproj", "{C18682B5-3246-4ED4-9527-3F51E89A7235}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ExportKey", "Examples\KeyOperations\ExportKey\ExportKey.csproj", "{0016534F-36AC-4B7A-8243-3D3E90976F6B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -157,6 +159,14 @@ Global
 		{C18682B5-3246-4ED4-9527-3F51E89A7235}.Release|Any CPU.Build.0 = Release|Any CPU
 		{C18682B5-3246-4ED4-9527-3F51E89A7235}.Release|x86.ActiveCfg = Release|Any CPU
 		{C18682B5-3246-4ED4-9527-3F51E89A7235}.Release|x86.Build.0 = Release|Any CPU
+		{0016534F-36AC-4B7A-8243-3D3E90976F6B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0016534F-36AC-4B7A-8243-3D3E90976F6B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0016534F-36AC-4B7A-8243-3D3E90976F6B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{0016534F-36AC-4B7A-8243-3D3E90976F6B}.Debug|x86.Build.0 = Debug|Any CPU
+		{0016534F-36AC-4B7A-8243-3D3E90976F6B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0016534F-36AC-4B7A-8243-3D3E90976F6B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0016534F-36AC-4B7A-8243-3D3E90976F6B}.Release|x86.ActiveCfg = Release|Any CPU
+		{0016534F-36AC-4B7A-8243-3D3E90976F6B}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -174,6 +184,7 @@ Global
 		{CA80E147-9549-483F-AC09-57A46891BBC2} = {F803B37B-3E35-43F8-A772-3A6D0ECB610A}
 		{F593613E-08BF-4B4C-A863-4FFD631E369B} = {F803B37B-3E35-43F8-A772-3A6D0ECB610A}
 		{B2B6890B-54C8-4BA7-AE61-F06E582A6A3C} = {F803B37B-3E35-43F8-A772-3A6D0ECB610A}
+		{0016534F-36AC-4B7A-8243-3D3E90976F6B} = {34B6A704-4985-40D1-8D8D-09C4C97227EA}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {76405F3E-1C3A-4FBE-9275-780388EAA45B}

--- a/gpgme-sharp/IKeyStore.cs
+++ b/gpgme-sharp/IKeyStore.cs
@@ -4,8 +4,8 @@
     {
         ImportResult Import(GpgmeData keydata);
 
-        void Export(string pattern, GpgmeData keydata);
-        void Export(string[] pattern, GpgmeData keydata);
+        void Export(string pattern, GpgmeData keydata, ExportMode? mode = null);
+        void Export(string[] pattern, GpgmeData keydata, ExportMode? mode = null);
 
         Key GetKey(string fpr, bool secretOnly);
         Key[] GetKeyList(string pattern, bool secretOnly);


### PR DESCRIPTION
 - Adds the GPG export modes as listed on https://www.gnupg.org/documentation/manuals/gpgme/Exporting-Keys.html, mainly to allow exporting secret keys
 - Added a basic example for key export
 - Added a simpler override for `Export`, taking a filename instead of having to pass an instance of `GpgmeData`