### PR TITLE
Add missing fields to Subkey: Curve, CardNumber and Keygrip

### DIFF
--- a/gpgme-sharp/Interop/_gpgme_subkey.cs
+++ b/gpgme-sharp/Interop/_gpgme_subkey.cs
@@ -66,6 +66,15 @@ namespace Libgpgme.Interop
         /* The expiration timestamp, 0 if the subkey does not expire.  */
         public IntPtr expires;
 
+        /* The serial number of a smart card holding this key or NULL.  */
+        public IntPtr card_number; // char*
+
+        /* The name of the curve for ECC algorithms or NULL.  */
+        public IntPtr curve; // char*
+
+        /* The keygrip of the subkey in hex digit form or NULL if not available. */
+        public IntPtr keygrip; // char*
+
         public bool revoked {
             get => ((flags & 1) > 0);
             set {

--- a/gpgme-sharp/Subkey.cs
+++ b/gpgme-sharp/Subkey.cs
@@ -12,7 +12,19 @@ namespace Libgpgme
         private long _timestamp;
 
         public string KeyId { get; private set; }
+        /// <summary>
+        /// The keygrip of the subkey in hex digit form or NULL if not availabale.
+        /// </summary>
+        public string Keygrip { get; private set; }
         public string Fingerprint { get; private set; }
+        /// <summary>
+        /// The name of the curve for ECC algorithms or NULL.
+        /// </summary>
+        public string Curve { get; private set; }
+        /// <summary>
+        /// The serial number of a smart card holding this key or NULL.
+        /// </summary>
+        public string CardNumber { get; private set; }
         public Subkey Next { get; private set; }
         public bool Revoked { get; private set; }
         public bool Expired { get; private set; }
@@ -105,6 +117,9 @@ namespace Libgpgme
 
             KeyId = Gpgme.PtrToStringAnsi(subkey.keyid);
             Fingerprint = Gpgme.PtrToStringAnsi(subkey.fpr);
+            Curve = Gpgme.PtrToStringAnsi(subkey.curve);
+            CardNumber = Gpgme.PtrToStringAnsi(subkey.card_number);
+            Keygrip = Gpgme.PtrToStringAnsi(subkey.keygrip);
             _timestamp = (long) subkey.timestamp;
             _expires = (long) subkey.expires;
 


### PR DESCRIPTION
Tested manually with the `ListKeys` sample... It worked fine:
![](https://user-images.githubusercontent.com/91933/54486648-6fad8a00-4848-11e9-9771-1b392351304a.png)


I really just needed `Keygrip`, but had to add `Curve` and `CardNumber` too, as they're also in the struct.